### PR TITLE
fix(web): hide scrollbars by default

### DIFF
--- a/apps/web-app/components/convos/convoList.vue
+++ b/apps/web-app/components/convos/convoList.vue
@@ -103,7 +103,7 @@
       <div
         v-if="userHasConvos"
         ref="infiniteContainer"
-        class="h-full max-h-full max-w-full w-full overflow-scroll">
+        class="h-full max-h-full max-w-full w-full overflow-auto">
         <DynamicScroller
           :items="convos"
           key-field="publicId"

--- a/apps/web-app/components/convos/convoMessages.vue
+++ b/apps/web-app/components/convos/convoMessages.vue
@@ -37,7 +37,7 @@
 </script>
 <template>
   <div
-    class="h-full max-h-full max-w-full w-full flex flex-col-reverse overflow-y-scroll">
+    class="h-full max-h-full max-w-full w-full flex flex-col-reverse overflow-y-auto">
     <div
       class="mb-[24px] mt-[24px] w-full flex flex-col-reverse items-start gap-4">
       <div

--- a/apps/web-app/components/convos/sidebar.vue
+++ b/apps/web-app/components/convos/sidebar.vue
@@ -3,7 +3,7 @@
 </script>
 <template>
   <div
-    class="h-full max-h-full flex flex-col gap-2 overflow-y-scroll border-r-1 border-base-6 pr-4">
+    class="h-full max-h-full flex flex-col gap-2 overflow-y-auto border-r-1 border-base-6 pr-4">
     <div class="flex grow flex-col gap-0 overflow-hidden">
       <convos-convo-list />
 

--- a/apps/web-app/components/settings/addNewEmail.vue
+++ b/apps/web-app/components/settings/addNewEmail.vue
@@ -239,7 +239,7 @@
 </script>
 
 <template>
-  <div class="h-full w-full flex flex-col items-start gap-8 overflow-y-scroll">
+  <div class="h-full w-full flex flex-col items-start gap-8 overflow-y-auto">
     <div class="w-full flex flex-col gap-8">
       <div class="w-full flex flex-col gap-4">
         <div class="w-full border-b-1 border-base-6">

--- a/apps/web-app/components/settings/addNewInvite.vue
+++ b/apps/web-app/components/settings/addNewInvite.vue
@@ -259,7 +259,7 @@
 </script>
 
 <template>
-  <div class="h-full w-full flex flex-col items-start gap-4 overflow-y-scroll">
+  <div class="h-full w-full flex flex-col items-start gap-4 overflow-y-auto">
     <div class="w-full flex flex-col gap-2">
       <div
         class="grid grid-cols-1 grid-rows-2 gap-2 md:grid-cols-2 md:grid-rows-1 md:gap-4">

--- a/apps/web-app/components/settings/sidebar.vue
+++ b/apps/web-app/components/settings/sidebar.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-  import type { VerticalNavigationLink } from '@nuxt/ui/dist/runtime/types/vertical-navigation';
-
   const { $trpc } = useNuxtApp();
 
   const orgSlug = useRoute().params.orgSlug as string;
@@ -68,9 +66,9 @@
   ]);
 </script>
 <template>
-  <div class="h-full max-h-full flex flex-col gap-2 overflow-y-scroll pr-4">
+  <div class="h-full max-h-full flex flex-col gap-2 overflow-y-auto pr-4">
     <div
-      class="h-full max-h-full flex grow flex-col gap-4 overflow-hidden overflow-y-scroll">
+      class="h-full max-h-full flex grow flex-col gap-4 overflow-hidden overflow-y-auto">
       <div class="w-full flex flex-col gap-2">
         <div>
           <span class="font-display">Personal</span>

--- a/apps/web-app/components/un/editor.vue
+++ b/apps/web-app/components/un/editor.vue
@@ -40,6 +40,6 @@
     class="h-full max-h-full w-full border border-1 border-base-6 rounded-xl bg-base-1 px-2 py-1">
     <EditorContent
       :editor="editor"
-      class="h-full max-h-full overflow-y-scroll" />
+      class="h-full max-h-full overflow-y-auto" />
   </div>
 </template>

--- a/apps/web-app/pages/[orgSlug]/convo/404.vue
+++ b/apps/web-app/pages/[orgSlug]/convo/404.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts"></script>
 <template>
   <div
-    class="h-full max-h-full w-full flex flex-col items-center justify-center gap-2 overflow-y-scroll align-middle">
+    class="h-full max-h-full w-full flex flex-col items-center justify-center gap-2 overflow-y-auto align-middle">
     <div class="flex flex-row gap-2 text-xl font-display">
       Oops, we cant find that conversation
     </div>

--- a/apps/web-app/pages/[orgSlug]/settings/org/mail/addresses/[emailIdentityId].vue
+++ b/apps/web-app/pages/[orgSlug]/settings/org/mail/addresses/[emailIdentityId].vue
@@ -19,7 +19,7 @@
 
 <template>
   <div
-    class="h-full w-full flex flex-col items-start gap-8 overflow-y-scroll p-4">
+    class="h-full w-full flex flex-col items-start gap-8 overflow-y-auto p-4">
     <div class="w-full flex flex-row items-center justify-between">
       <div class="flex flex-row items-center gap-4">
         <UnUiTooltip text="Back to Email Address list">

--- a/apps/web-app/pages/[orgSlug]/settings/org/mail/addresses/index.vue
+++ b/apps/web-app/pages/[orgSlug]/settings/org/mail/addresses/index.vue
@@ -109,7 +109,7 @@
         </UnUiModal>
       </div>
     </div>
-    <div class="w-full flex flex-col gap-4 overflow-y-scroll">
+    <div class="w-full flex flex-col gap-4 overflow-y-auto">
       <NuxtUiTable
         :columns="tableColumns"
         :rows="tableRows"

--- a/apps/web-app/pages/[orgSlug]/settings/org/mail/domains/[domainId].vue
+++ b/apps/web-app/pages/[orgSlug]/settings/org/mail/domains/[domainId].vue
@@ -160,7 +160,7 @@
         :label="domainStatus.toUpperCase()"
         size="lg" />
     </div>
-    <div class="w-full flex flex-col gap-8 overflow-y-scroll">
+    <div class="w-full flex flex-col gap-8 overflow-y-auto">
       <div
         v-if="domainPending"
         class="w-full flex flex-col gap-8">

--- a/apps/web-app/pages/[orgSlug]/settings/org/mail/domains/index.vue
+++ b/apps/web-app/pages/[orgSlug]/settings/org/mail/domains/index.vue
@@ -108,7 +108,7 @@
         </UnUiModal>
       </div>
     </div>
-    <div class="w-full flex flex-col gap-8 overflow-y-scroll">
+    <div class="w-full flex flex-col gap-8 overflow-y-auto">
       <div class="w-full flex flex-col gap-8">
         <NuxtUiTable
           :columns="tableColumns"

--- a/apps/web-app/pages/[orgSlug]/settings/org/setup/billing.vue
+++ b/apps/web-app/pages/[orgSlug]/settings/org/setup/billing.vue
@@ -68,7 +68,7 @@
       </div>
     </div>
 
-    <div class="w-full flex flex-col gap-8 overflow-y-scroll">
+    <div class="w-full flex flex-col gap-8 overflow-y-auto">
       <div
         v-if="pending"
         class="w-full flex flex-col gap-8">

--- a/apps/web-app/pages/[orgSlug]/settings/org/users/groups/[groupId].vue
+++ b/apps/web-app/pages/[orgSlug]/settings/org/users/groups/[groupId].vue
@@ -207,7 +207,7 @@
         </div>
       </div>
     </div>
-    <div class="w-full flex flex-col gap-8 overflow-y-scroll">
+    <div class="w-full flex flex-col gap-8 overflow-y-auto">
       <div
         v-if="groupPending"
         class="w-full flex flex-col gap-8">

--- a/apps/web-app/pages/[orgSlug]/settings/org/users/groups/index.vue
+++ b/apps/web-app/pages/[orgSlug]/settings/org/users/groups/index.vue
@@ -99,7 +99,7 @@
         </UnUiModal>
       </div>
     </div>
-    <div class="w-full flex flex-col gap-4 overflow-y-scroll">
+    <div class="w-full flex flex-col gap-4 overflow-y-auto">
       <NuxtUiTable
         :columns="tableColumns"
         :rows="tableRows"

--- a/apps/web-app/pages/[orgSlug]/settings/org/users/invites/index.vue
+++ b/apps/web-app/pages/[orgSlug]/settings/org/users/invites/index.vue
@@ -162,7 +162,7 @@
         </UnUiModal>
       </div>
     </div>
-    <div class="w-full flex flex-col gap-8 overflow-y-scroll">
+    <div class="w-full flex flex-col gap-8 overflow-y-auto">
       <div class="w-full flex flex-col gap-8">
         <NuxtUiTable
           :columns="tableColumns"

--- a/apps/web-app/pages/[orgSlug]/settings/org/users/members/index.vue
+++ b/apps/web-app/pages/[orgSlug]/settings/org/users/members/index.vue
@@ -93,7 +93,7 @@
         </button>
       </div>
     </div>
-    <div class="w-full flex flex-col gap-4 overflow-y-scroll">
+    <div class="w-full flex flex-col gap-4 overflow-y-auto">
       <NuxtUiTable
         :columns="tableColumns"
         :rows="tableRows"

--- a/apps/web-app/pages/join/secure.vue
+++ b/apps/web-app/pages/join/secure.vue
@@ -270,7 +270,7 @@
 </script>
 
 <template>
-  <div class="h-screen w-screen flex flex-col items-center justify-between p-4">
+  <div class="h-screen w-full flex flex-col items-center justify-between p-4">
     <div
       class="max-w-72 w-full flex grow flex-col items-center justify-center gap-8 pb-14 md:max-w-xl">
       <h1 class="mb-4 text-center text-2xl font-display">


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #100

<!-- If there isn't an issue for this PR, please re-review our Contributing Guide and create an issue -->

## Type of change

This PR fixes having scrollbar everywhere by making overflow auto. Its not a perfect solution as when scrollbar becomes visible, it shifts the content to the left. But it is better than having scrollbar everywhere.

In near future, we should consider using [Radix Scroll Area](https://www.radix-vue.com/components/scroll-area.html) or the shadcn version of that.

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Tested my code in a local environment
- [ ] Commented on my code in hard-to-understand areas
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the UnInbox Docs if changes were necessary
