### PR TITLE
feat(mail-parser): improve signature/quote detection, add new style cleaner

### DIFF
--- a/packages/mailtools/src/prepareMessage.ts
+++ b/packages/mailtools/src/prepareMessage.ts
@@ -29,7 +29,7 @@ export interface PrepareMessageOptions {
   /** Append the given style to the HTML <head> */
   includeStyle?: string;
   /** Remove specific styles that could affect the rendering of the html */
-  cleanStyles?: string;
+  cleanStyles?: boolean;
 }
 
 /**

--- a/packages/mailtools/src/prepareMessage.ts
+++ b/packages/mailtools/src/prepareMessage.ts
@@ -1,13 +1,17 @@
-import { load, type CheerioAPI } from "cheerio";
-import removeQuotations from "./removeQuotations";
-import removeTrailingWhitespace from "./removeTrailingWhitespace";
-import linkify from "./linkify";
-import enforceViewport from "./enforceViewport";
-import { blockRemoteContentCheerio, type ReplacementOptions } from "./blockRemoteContent";
-import { containsEmptyText, getTopLevelElement } from "./cheerio-utils";
-import appendStyle from "./appendStyle";
-import fixBrokenHtml from "./fixBrokenHtml";
-import { enhanceLinks as _enhanceLinks } from "./enhanceLinks";
+import { load, type CheerioAPI } from 'cheerio';
+import removeQuotations from './removeQuotations';
+import removeTrailingWhitespace from './removeTrailingWhitespace';
+import linkify from './linkify';
+import enforceViewport from './enforceViewport';
+import {
+  blockRemoteContentCheerio,
+  type ReplacementOptions
+} from './blockRemoteContent';
+import { containsEmptyText, getTopLevelElement } from './cheerio-utils';
+import appendStyle from './appendStyle';
+import fixBrokenHtml from './fixBrokenHtml';
+import { enhanceLinks as _enhanceLinks } from './enhanceLinks';
+import removeStyles from './removeStyles';
 
 export interface PrepareMessageOptions {
   /** Remove quotations and signatures. Only affects the result messageHtml */
@@ -24,6 +28,8 @@ export interface PrepareMessageOptions {
   remoteContentReplacements?: ReplacementOptions;
   /** Append the given style to the HTML <head> */
   includeStyle?: string;
+  /** Remove specific styles that could affect the rendering of the html */
+  cleanStyles?: string;
 }
 
 /**
@@ -38,7 +44,7 @@ export interface PrepareMessageOptions {
  */
 function prepareMessage(
   emailHtml: string,
-  options: PrepareMessageOptions = {},
+  options: PrepareMessageOptions = {}
 ): {
   /** The complete message. */
   completeHtml: string;
@@ -54,13 +60,14 @@ function prepareMessage(
     forceViewport = false,
     noRemoteContent = false,
     includeStyle = false,
-    remoteContentReplacements = {},
+    cleanStyles = false,
+    remoteContentReplacements = {}
   } = options;
 
   const result = {
     messageHtml: emailHtml,
     completeHtml: emailHtml,
-    didFindQuotation: false,
+    didFindQuotation: false
   };
 
   result.completeHtml = fixBrokenHtml(result.completeHtml);
@@ -93,6 +100,9 @@ function prepareMessage(
   if (includeStyle) {
     appendStyle($, includeStyle);
   }
+  if (cleanStyles) {
+    removeStyles($);
+  }
 
   removeTrailingWhitespace($);
   result.completeHtml = $.html();
@@ -124,10 +134,10 @@ function removeTrackers($: CheerioAPI): void {
     'img[width="1"]',
     'img[height="0"]',
     'img[height="1"]',
-    'img[src*="http://mailstat.us"]',
+    'img[src*="http://mailstat.us"]'
   ];
 
-  const query = TRACKERS_SELECTORS.join(", ");
+  const query = TRACKERS_SELECTORS.join(', ');
 
   $(query).each((_, el) => {
     $(el).remove();
@@ -135,16 +145,16 @@ function removeTrackers($: CheerioAPI): void {
 }
 
 function removeScripts($: CheerioAPI): void {
-  $("script").each((_, el) => {
+  $('script').each((_, el) => {
     $(el).remove();
   });
 }
 
 function removeComments($: CheerioAPI): void {
-  $("*")
+  $('*')
     .contents()
     .each((_, el) => {
-      if (el.type === "comment") {
+      if (el.type === 'comment') {
         $(el).remove();
       }
     });

--- a/packages/mailtools/src/removeQuotations.ts
+++ b/packages/mailtools/src/removeQuotations.ts
@@ -1,8 +1,8 @@
-import { isImage, toArray, isEmptyLike } from "./cheerio-utils";
-import { isText } from "domhandler";
-import findQuoteString from "./findQuoteString";
-import type { CheerioAPI } from "cheerio";
-import type { AnyNode, Element } from "domhandler";
+import { isImage, toArray, isEmptyLike } from './cheerio-utils';
+import { isText } from 'domhandler';
+import findQuoteString from './findQuoteString';
+import type { CheerioAPI } from 'cheerio';
+import type { AnyNode, Element } from 'domhandler';
 
 /**
  * Remove quotations (replied messages) and signatures from the HTML
@@ -30,20 +30,24 @@ function removeQuotations($: CheerioAPI): { didFindQuotation: boolean } {
 function findAllQuotes($: CheerioAPI) {
   const quoteElements = $(
     [
-      ".gmail_quote",
-      "blockquote",
+      '.gmail_quote',
+      'blockquote',
+      '[class*="quote"]', // quote partial match for class names
+      '[id*="quote"]', // quote partial match for id names
       // Signatures.
-      ".gmail_signature",
-      "signature",
+      '.gmail_signature',
+      'signature',
+      '[class*="sig"]', // sig partial match for class names
+      '[id*="sig"]' // sig partial match for id names
       // ENHANCEMENT: Add findQuotesAfterMessageHeaderBlock
       // ENHANCEMENT: Add findQuotesAfter__OriginalMessage__
-    ].join(", "),
+    ].join(', ')
   );
   // console.log(quoteElements.html());
   // Ignore inline quotes. Quotes that are followed by non-quote blocks.
   const quoteElementsSet = new Set(toArray(quoteElements));
   const withoutInlineQuotes = quoteElements.filter(
-    (i, el) => !isInlineQuote(el as Element, quoteElementsSet as Set<Element>),
+    (i, el) => !isInlineQuote(el as Element, quoteElementsSet as Set<Element>)
   );
 
   return withoutInlineQuotes;

--- a/packages/mailtools/src/removeStyles.ts
+++ b/packages/mailtools/src/removeStyles.ts
@@ -1,0 +1,37 @@
+import type { CheerioAPI } from 'cheerio';
+
+/**
+ * Remove specific style attributes from all dom elements.
+ * Returns true once completed
+ */
+function removeStyles($: CheerioAPI): boolean {
+  const cssAttributesToRemove = [
+    'color',
+    'background-color',
+    'font-family',
+    'font-size'
+  ];
+  $('*').each((index, element) => {
+    const style = $(element).attr('style');
+    if (style !== undefined && style.trim() === '') {
+      $(element).removeAttr('style');
+    } else if (style) {
+      const styles = style.split(';');
+      const filteredStyles = styles.filter((style) => {
+        const propertyName = style.split(':')[0].trim();
+        return !cssAttributesToRemove.includes(propertyName);
+      });
+      if (
+        filteredStyles.length === 0 ||
+        (filteredStyles.length === 1 && filteredStyles[0] === '')
+      ) {
+        $(element).removeAttr('style');
+      } else {
+        $(element).attr('style', filteredStyles.join(';'));
+      }
+    }
+  });
+  return true;
+}
+
+export default removeStyles;


### PR DESCRIPTION
## What does this PR do?

this adds 1 new function to the mail-parser to clean up and remove some specific style attributes
it also adds new ways to match signatures and quotes that should cover a much wider range of email providers

Fixes #116 


## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Chore (refactoring code, technical debt, workflow improvements)
- [X] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required
- [X] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [X] Self-reviewed my own code
- [X] Tested my code in a local environment
- [X] Commented on my code in hard-to-understand areas
- [X] Checked for warnings, there are none
- [X] Removed all `console.logs`
- [X] Merged the latest changes from main onto my branch with `git pull origin main`
- [X] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the UnInbox Docs if changes were necessary
