### PR TITLE
feat(mailtools): add playground, refactor signature extractions

### DIFF
--- a/packages/mailtools/package.json
+++ b/packages/mailtools/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup",
+    "start": "tsx playground/index.ts",
     "test": "vitest run",
     "test:ui": "vitest --ui"
   },
@@ -38,6 +39,7 @@
     "domhandler": "^5.0.3",
     "prettier": "^3.2.5",
     "tsup": "^8.0.2",
+    "tsx": "^4.7.1",
     "typescript": "^5.3.3",
     "vitest": "^1.3.1"
   },

--- a/packages/mailtools/playground/index.ts
+++ b/packages/mailtools/playground/index.ts
@@ -1,0 +1,31 @@
+import { parseMessage } from '../src';
+import type { ParseMessageOptions, ReplacementOptions } from '../src/';
+
+const htmlToParse = `<div dir="ltr">heres a text line<br clear="all"><div><div dir="ltr" class="gmail_signature" data-smartmail="gmail_signature"><div dir="ltr"><div><div dir="ltr"><div><div dir="ltr"><div><div dir="ltr"><div><div style="font-size:12.6667px"><b>Omar McPizza</b></div></div><div style="font-size:12.6667px"><b><br></b></div><div style="font-size:12.6667px"><b>+34 69 420 1337</b></div></div></div></div></div></div></div></div></div></div><br></div><br><div class="gmail_quote"><div dir="ltr" class="gmail_attr">On Thu, Feb 29, 2024 at 10:00 PM Omar McPizza &lt;<a href="mailto:omcpizza@example.com">omcpizza@example.com</a>&gt; wrote:<br></div><blockquote class="gmail_quote" style="margin:0px 0px 0px 0.8ex;border-left-width:1px;border-left-style:solid;border-left-color:rgb(204,204,204);padding-left:1ex"><div style="font-family:Arial,sans-serif;font-size:14px">lets see how this all comes out now</div><div style="font-family:Arial,sans-serif;font-size:14px"></div></blockquote></div>`;
+
+const parseOptions: ParseMessageOptions = {
+  /** Remove quotations. Only affects the result messageHtml */
+  cleanQuotations: false,
+  /** Remove and return signatures. Only affects the result messageHtml */
+  cleanSignatures: false,
+  /** Automatically convert text links to anchor tags */
+  autolink: false,
+  /** Fix broken links and add the href to the title tag */
+  enhanceLinks: false,
+  /** Specific viewport to enforce. For example "<meta name="viewport" content="width=device-width">" */
+  forceViewport: false,
+  /** Replace remote images with a transparent image, and replace other remote URLs with '#' */
+  noRemoteContent: false,
+  /** Replace remote content with custom URLs */
+  remoteContentReplacements: {} as ReplacementOptions,
+  /** Append the given style to the HTML <head> */
+  includeStyle: false,
+  /** Remove specific styles that could affect the rendering of the html */
+  cleanStyles: false
+};
+
+console.log('Running parseMessage with the following options:');
+console.log({ parseOptions });
+
+const parsed = await parseMessage(htmlToParse, parseOptions);
+console.log(parsed);

--- a/packages/mailtools/src/index.ts
+++ b/packages/mailtools/src/index.ts
@@ -1,6 +1,8 @@
-import linkify from "./linkify";
-import prepareMessage from "./prepareMessage";
-import { blockRemoteContent } from "./blockRemoteContent";
+import linkify from './linkify';
+import { parseMessage } from './parseMessage';
+import { blockRemoteContent } from './blockRemoteContent';
+import type { ReplacementOptions } from './blockRemoteContent';
+import type { ParseMessageOptions } from './parseMessage';
 
-export default prepareMessage;
-export { linkify, blockRemoteContent };
+export { parseMessage, linkify, blockRemoteContent };
+export type { ParseMessageOptions, ReplacementOptions };

--- a/packages/mailtools/src/removeQuotations.ts
+++ b/packages/mailtools/src/removeQuotations.ts
@@ -33,12 +33,7 @@ function findAllQuotes($: CheerioAPI) {
       '.gmail_quote',
       'blockquote',
       '[class*="quote"]', // quote partial match for class names
-      '[id*="quote"]', // quote partial match for id names
-      // Signatures.
-      '.gmail_signature',
-      'signature',
-      '[class*="sig"]', // sig partial match for class names
-      '[id*="sig"]' // sig partial match for id names
+      '[id*="quote"]' // quote partial match for id names
       // ENHANCEMENT: Add findQuotesAfterMessageHeaderBlock
       // ENHANCEMENT: Add findQuotesAfter__OriginalMessage__
     ].join(', ')

--- a/packages/mailtools/src/removeSignatures.ts
+++ b/packages/mailtools/src/removeSignatures.ts
@@ -1,0 +1,92 @@
+import { load } from 'cheerio';
+import type { CheerioAPI } from 'cheerio';
+import removeQuotations from './removeQuotations';
+
+/**
+ * Remove Signatures from the HTML and return the signatures in plain text and html
+ */
+function removeSignatures(
+  $: CheerioAPI,
+  cleanedQuotations: boolean = false
+): {
+  didFindSignature: boolean;
+  foundSignaturePlainText: string | null;
+  foundSignatureHtml: string | null;
+} {
+  const returnData = {
+    didFindSignature: false as boolean,
+    foundSignaturePlainText: null as string | null,
+    foundSignatureHtml: null as string | null
+  };
+
+  let cheerioToSearchForSignatures: CheerioAPI;
+  let cheerioToSearchRemoveSignatures: CheerioAPI;
+  // if cleanedQuotations is true, we assume that the quotations were already removed and we can just extract the first signature and return it
+  if (cleanedQuotations) {
+    cheerioToSearchForSignatures = $;
+    cheerioToSearchRemoveSignatures = $;
+  } else {
+    // if cleanedQuotations is false, we need to remove the quotations first then run the signature extraction on the new cloned item, then run the signature removal on the original item
+    const cloned$ = load($('*').html() || '');
+    removeQuotations(cloned$);
+    cheerioToSearchForSignatures = cloned$;
+    cheerioToSearchRemoveSignatures = $;
+  }
+
+  // extract the signature for the return data from the html without the quotes
+  const foundPrimarySignatureElements = findAllSignatures(
+    cheerioToSearchForSignatures
+  );
+  const foundPrimarySignature = foundPrimarySignatureElements.first();
+
+  // Iterate over divs and remove those that only contain a single div child
+  foundPrimarySignature.find('div').each(function () {
+    const div = $(this);
+    // Check if the div only has one child and that child is a div
+    if (div.children().length === 1 && div.children('div').length === 1) {
+      const childDiv = div.children('div').first();
+      // Replace the parent div with its child div directly
+      div.replaceWith(childDiv);
+    }
+  });
+
+  returnData.foundSignatureHtml = foundPrimarySignature.html();
+
+  // Now proceed with inserting line breaks for plain text
+  foundPrimarySignature.find('div').each(function (i, el) {
+    if (i > 0) {
+      // Skip the first div to avoid a leading newline
+      $(el).before('\n');
+    }
+  });
+  returnData.foundSignaturePlainText = foundPrimarySignature.text().trim();
+
+  // remove all the signatures from the original email
+  const allSignatureElementsForRemoval = findAllSignatures(
+    cheerioToSearchRemoveSignatures
+  );
+  allSignatureElementsForRemoval.each((_, el) => void $(el).remove());
+
+  returnData.didFindSignature = foundPrimarySignatureElements.length > 0;
+
+  return returnData;
+}
+
+/**
+ * Returns a selection of all signature elements
+ */
+function findAllSignatures($: CheerioAPI) {
+  const signatureElements = $(
+    [
+      // Signatures.
+      '.gmail_signature',
+      'signature',
+      '[class*="sig"]', // sig partial match for class names
+      '[id*="sig"]' // sig partial match for id names
+    ].join(', ')
+  );
+
+  return signatureElements;
+}
+
+export default removeSignatures;

--- a/packages/mailtools/src/removeSignatures.ts
+++ b/packages/mailtools/src/removeSignatures.ts
@@ -81,8 +81,8 @@ function findAllSignatures($: CheerioAPI) {
       // Signatures.
       '.gmail_signature',
       'signature',
-      '[class*="sig"]', // sig partial match for class names
-      '[id*="sig"]' // sig partial match for id names
+      '[class*="signature"]', // sig partial match for class names
+      '[id*="signature"]' // sig partial match for id names
     ].join(', ')
   );
 

--- a/packages/mailtools/src/removeStyles.ts
+++ b/packages/mailtools/src/removeStyles.ts
@@ -4,9 +4,8 @@ import type { CheerioAPI } from 'cheerio';
  * Remove specific style attributes from all dom elements.
  * Returns true once completed
  */
-function removeStyles($: CheerioAPI): boolean {
-  const cssAttributesToRemove = [
-    'color',
+function removeStyles($: CheerioAPI, styles?: string[]): boolean {
+  const cssAttributesToRemove = styles || [
     'background-color',
     'font-family',
     'font-size'
@@ -18,7 +17,11 @@ function removeStyles($: CheerioAPI): boolean {
     } else if (style) {
       const styles = style.split(';');
       const filteredStyles = styles.filter((style) => {
-        const propertyName = style.split(':')[0].trim();
+        const splitStyles = style.split(':');
+        if (!splitStyles[0]) {
+          return false;
+        }
+        const propertyName = splitStyles[0].trim() || '';
         return !cssAttributesToRemove.includes(propertyName);
       });
       if (

--- a/packages/mailtools/src/tests/prepareMessage/generateFixtureOutputs.ts
+++ b/packages/mailtools/src/tests/prepareMessage/generateFixtureOutputs.ts
@@ -1,6 +1,6 @@
 import Fs from 'fs';
 import { listFixtures } from './fixtures';
-import prepareMessage from '../../prepareMessage';
+import { parseMessage } from '../../parseMessage';
 import { formatHtml } from '../utils';
 import testOptions from './prepareMessageTestOptions';
 
@@ -11,11 +11,11 @@ listFixtures()
   .forEach(async (fixture) => {
     console.log('Found lonely input fixture: ' + fixture.name);
 
-    const result = prepareMessage(fixture.input, testOptions);
+    const result = await parseMessage(fixture.input, testOptions);
 
     Fs.writeFileSync(
       fixture.outputMessagePath,
-      await formatHtml(result.messageHtml)
+      await formatHtml(result.parsedMessageHtml)
     );
     console.log('Wrote: ' + fixture.outputMessagePath);
 

--- a/packages/mailtools/src/tests/prepareMessage/prepareMessage.test.ts
+++ b/packages/mailtools/src/tests/prepareMessage/prepareMessage.test.ts
@@ -1,5 +1,5 @@
 import { formatHtml } from '../utils';
-import prepareMessage from '../../prepareMessage';
+import { parseMessage } from '../../parseMessage';
 import { listFixtures, Fixture } from './fixtures';
 import testOptions from './prepareMessageTestOptions';
 
@@ -7,8 +7,8 @@ import testOptions from './prepareMessageTestOptions';
  * Run tests for a fixture
  */
 function checkFixture(fixture: Fixture) {
-  describe(fixture.name, () => {
-    const result = prepareMessage(fixture.input, testOptions);
+  describe(fixture.name, async () => {
+    const result = await parseMessage(fixture.input, testOptions);
 
     if (fixture.hasOutputComplete()) {
       it('completeHtml', async () => {
@@ -21,7 +21,7 @@ function checkFixture(fixture: Fixture) {
     if (fixture.hasOutputMessage()) {
       // console.log(result.messageHtml);
       it('messageHtml', async () => {
-        expect(await formatHtml(result.messageHtml)).toBe(
+        expect(await formatHtml(result.parsedMessageHtml)).toBe(
           await formatHtml(fixture.outputMessage)
         );
       });

--- a/packages/mailtools/src/tests/prepareMessage/prepareMessageTestOptions.ts
+++ b/packages/mailtools/src/tests/prepareMessage/prepareMessageTestOptions.ts
@@ -1,7 +1,8 @@
-import type { PrepareMessageOptions } from '../../prepareMessage';
+import type { ParseMessageOptions } from '../../parseMessage';
 
-const testOptions: PrepareMessageOptions = {
-  noQuotations: true,
+const testOptions: ParseMessageOptions = {
+  cleanQuotations: true,
+  cleanSignatures: true,
   autolink: true,
   enhanceLinks: true,
   noRemoteContent: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 importers:
 
   .:
@@ -468,6 +464,9 @@ importers:
       tsup:
         specifier: ^8.0.2
         version: 8.0.2(typescript@5.3.3)
+      tsx:
+        specifier: ^4.7.1
+        version: 4.7.1
       typescript:
         specifier: ^5.3.3
         version: 5.3.3
@@ -531,7 +530,7 @@ importers:
         version: 5.1.3(@types/node@20.11.19)
       vitest:
         specifier: ^1.3.1
-        version: 1.3.1(@types/node@20.11.19)
+        version: 1.3.1(@types/node@20.11.24)(@vitest/ui@1.3.1)
 
   packages/tiptap:
     dependencies:
@@ -4060,7 +4059,7 @@ packages:
       semver: 7.6.0
       simple-git: 3.22.0
       sirv: 2.0.4
-      unimport: 3.7.1
+      unimport: 3.7.1(rollup@4.12.0)
       vite: 5.1.4(@types/node@20.11.19)
       vite-plugin-inspect: 0.8.3(@nuxt/kit@3.10.2)(vite@5.1.4)
       vite-plugin-vue-inspector: 4.0.2(vite@5.1.4)
@@ -4108,7 +4107,7 @@ packages:
       semver: 7.6.0
       ufo: 1.4.0
       unctx: 2.3.1
-      unimport: 3.7.1
+      unimport: 3.7.1(rollup@4.12.0)
       untyped: 1.4.2
     transitivePeerDependencies:
       - rollup
@@ -4134,7 +4133,7 @@ packages:
       semver: 7.6.0
       ufo: 1.4.0
       unctx: 2.3.1
-      unimport: 3.7.1
+      unimport: 3.7.1(rollup@4.12.0)
       untyped: 1.4.2
     transitivePeerDependencies:
       - rollup
@@ -4153,7 +4152,7 @@ packages:
       scule: 1.3.0
       std-env: 3.7.0
       ufo: 1.4.0
-      unimport: 3.7.1
+      unimport: 3.7.1(rollup@4.12.0)
       untyped: 1.4.2
     transitivePeerDependencies:
       - rollup
@@ -4172,7 +4171,7 @@ packages:
       scule: 1.3.0
       std-env: 3.7.0
       ufo: 1.4.0
-      unimport: 3.7.1
+      unimport: 3.7.1(rollup@4.12.0)
       untyped: 1.4.2
     transitivePeerDependencies:
       - rollup
@@ -4296,7 +4295,7 @@ packages:
       vue: ^3.3.4
     dependencies:
       '@nuxt/kit': 3.10.2
-      '@rollup/plugin-replace': 5.0.5
+      '@rollup/plugin-replace': 5.0.5(rollup@3.29.4)
       '@vitejs/plugin-vue': 5.0.4(vite@5.1.1)(vue@3.4.19)
       '@vitejs/plugin-vue-jsx': 3.1.0(vite@5.1.1)(vue@3.4.19)
       autoprefixer: 10.4.17(postcss@8.4.35)
@@ -5152,18 +5151,6 @@ packages:
       resolve: 1.22.8
       rollup: 4.12.0
 
-  /@rollup/plugin-replace@5.0.5:
-    resolution: {integrity: sha512-rYO4fOi8lMaTg/z5Jb+hKnrHHVn8j2lwkqwyS4kTRhKyWOLf2wST2sWXr4WzWiTcoHTp2sTjqUbqIj2E39slKQ==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-    dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
-      magic-string: 0.30.7
-
   /@rollup/plugin-replace@5.0.5(rollup@3.29.4):
     resolution: {integrity: sha512-rYO4fOi8lMaTg/z5Jb+hKnrHHVn8j2lwkqwyS4kTRhKyWOLf2wST2sWXr4WzWiTcoHTp2sTjqUbqIj2E39slKQ==}
     engines: {node: '>=14.0.0'}
@@ -5176,7 +5163,6 @@ packages:
       '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
       magic-string: 0.30.7
       rollup: 3.29.4
-    dev: true
 
   /@rollup/plugin-replace@5.0.5(rollup@4.12.0):
     resolution: {integrity: sha512-rYO4fOi8lMaTg/z5Jb+hKnrHHVn8j2lwkqwyS4kTRhKyWOLf2wST2sWXr4WzWiTcoHTp2sTjqUbqIj2E39slKQ==}
@@ -5203,7 +5189,7 @@ packages:
       rollup: 4.12.0
       serialize-javascript: 6.0.2
       smob: 1.4.1
-      terser: 5.27.0
+      terser: 5.28.1
 
   /@rollup/plugin-wasm@6.2.2(rollup@4.12.0):
     resolution: {integrity: sha512-gpC4R1G9Ni92ZIRTexqbhX7U+9estZrbhP+9SRb0DW9xpB9g7j34r+J2hqrcW/lRI7dJaU84MxZM0Rt82tqYPQ==}
@@ -10199,7 +10185,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 6.21.0(@typescript-eslint/parser@6.21.0)(eslint@8.56.0)(typescript@5.3.3)
       '@typescript-eslint/utils': 6.21.0(eslint@8.56.0)(typescript@5.3.3)
       eslint: 8.56.0
-      vitest: 1.3.1(@types/node@20.11.19)
+      vitest: 1.3.1(@types/node@20.11.24)(@vitest/ui@1.3.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -10323,7 +10309,7 @@ packages:
     resolution: {integrity: sha512-tmaM9gfnSWqzePVJ5FJLYX9mMyE6ZevvOIvd1CMoMk2Fn1F3aKI/OQPjubS5wCIKlPpWfDfKFEtoslCNCiZJpQ==}
     hasBin: true
     dependencies:
-      tsx: 4.7.0
+      tsx: 4.7.1
     dev: true
 
   /espree@9.6.1:
@@ -13924,7 +13910,7 @@ packages:
       uncrypto: 0.1.3
       unctx: 2.3.1
       unenv: 1.9.0
-      unimport: 3.7.1
+      unimport: 3.7.1(rollup@4.12.0)
       unplugin: 1.7.1
       unplugin-vue-router: 0.7.0(vue-router@4.2.5)(vue@3.4.19)
       untyped: 1.4.2
@@ -14033,7 +14019,7 @@ packages:
       uncrypto: 0.1.3
       unctx: 2.3.1
       unenv: 1.9.0
-      unimport: 3.7.1
+      unimport: 3.7.1(rollup@4.12.0)
       unplugin: 1.7.1
       unplugin-vue-router: 0.7.0(vue-router@4.2.5)(vue@3.4.19)
       untyped: 1.4.2
@@ -16638,16 +16624,6 @@ packages:
       webpack: 5.90.3
     dev: false
 
-  /terser@5.27.0:
-    resolution: {integrity: sha512-bi1HRwVRskAjheeYl291n3JC4GgO/Ty4z1nVs5AAsmonJulGxpSektecnNedrwK9C7vpvVtcX3cw00VSLt7U2A==}
-    engines: {node: '>=10'}
-    hasBin: true
-    dependencies:
-      '@jridgewell/source-map': 0.3.5
-      acorn: 8.11.3
-      commander: 2.20.3
-      source-map-support: 0.5.21
-
   /terser@5.28.1:
     resolution: {integrity: sha512-wM+bZp54v/E9eRRGXb5ZFDvinrJIOaTapx3WUokyVGZu5ucVCK55zEgGd5Dl2fSr3jUo5sDiERErUWLY6QPFyA==}
     engines: {node: '>=10'}
@@ -16657,7 +16633,6 @@ packages:
       acorn: 8.11.3
       commander: 2.20.3
       source-map-support: 0.5.21
-    dev: false
 
   /text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
@@ -16855,17 +16830,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - ts-node
-    dev: true
-
-  /tsx@4.7.0:
-    resolution: {integrity: sha512-I+t79RYPlEYlHn9a+KzwrvEwhJg35h/1zHsLC2JXvhC2mdynMv6Zxzvhv5EMV6VF5qJlLlkSnMVvdZV3PSIGcg==}
-    engines: {node: '>=18.0.0'}
-    hasBin: true
-    dependencies:
-      esbuild: 0.19.12
-      get-tsconfig: 4.7.2
-    optionalDependencies:
-      fsevents: 2.3.3
     dev: true
 
   /tsx@4.7.1:
@@ -17166,25 +17130,6 @@ packages:
       trough: 2.2.0
       vfile: 6.0.1
     dev: false
-
-  /unimport@3.7.1:
-    resolution: {integrity: sha512-V9HpXYfsZye5bPPYUgs0Otn3ODS1mDUciaBlXljI4C2fTwfFpvFZRywmlOu943puN9sncxROMZhsZCjNXEpzEQ==}
-    dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
-      acorn: 8.11.3
-      escape-string-regexp: 5.0.0
-      estree-walker: 3.0.3
-      fast-glob: 3.3.2
-      local-pkg: 0.5.0
-      magic-string: 0.30.7
-      mlly: 1.6.1
-      pathe: 1.1.2
-      pkg-types: 1.0.3
-      scule: 1.3.0
-      strip-literal: 1.3.0
-      unplugin: 1.7.1
-    transitivePeerDependencies:
-      - rollup
 
   /unimport@3.7.1(rollup@4.12.0):
     resolution: {integrity: sha512-V9HpXYfsZye5bPPYUgs0Otn3ODS1mDUciaBlXljI4C2fTwfFpvFZRywmlOu943puN9sncxROMZhsZCjNXEpzEQ==}
@@ -17923,62 +17868,6 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vitest@1.3.1(@types/node@20.11.19):
-    resolution: {integrity: sha512-/1QJqXs8YbCrfv/GPQ05wAZf2eakUPLPa18vkJAKE7RXOKfVHqMZZ1WlTjiwl6Gcn65M5vpNUB6EFLnEdRdEXQ==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': 1.3.1
-      '@vitest/ui': 1.3.1
-      happy-dom: '*'
-      jsdom: '*'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@types/node':
-        optional: true
-      '@vitest/browser':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
-        optional: true
-    dependencies:
-      '@types/node': 20.11.19
-      '@vitest/expect': 1.3.1
-      '@vitest/runner': 1.3.1
-      '@vitest/snapshot': 1.3.1
-      '@vitest/spy': 1.3.1
-      '@vitest/utils': 1.3.1
-      acorn-walk: 8.3.2
-      chai: 4.4.1
-      debug: 4.3.4
-      execa: 8.0.1
-      local-pkg: 0.5.0
-      magic-string: 0.30.7
-      pathe: 1.1.2
-      picocolors: 1.0.0
-      std-env: 3.7.0
-      strip-literal: 2.0.0
-      tinybench: 2.6.0
-      tinypool: 0.8.2
-      vite: 5.1.3(@types/node@20.11.19)
-      vite-node: 1.3.1(@types/node@20.11.19)
-      why-is-node-running: 2.2.2
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-    dev: true
-
   /vitest@1.3.1(@types/node@20.11.24)(@vitest/ui@1.3.1):
     resolution: {integrity: sha512-/1QJqXs8YbCrfv/GPQ05wAZf2eakUPLPa18vkJAKE7RXOKfVHqMZZ1WlTjiwl6Gcn65M5vpNUB6EFLnEdRdEXQ==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -18600,3 +18489,7 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: false
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false


### PR DESCRIPTION
## What does this PR do?

Fixes #120  #121 

This pr introduces a playground for local testing of the mailtools package

we have also split out the signature parser from the quotations parser
it now returns the parsed signatures in plain text and html

and the cleanstyles function can now accept an array of styles to remove, or if set to true will remove default styles

**NOT DONE:**
tests were not added for the new stuff... 

<!-- If there isn't an issue for this PR, please re-review our Contributing Guide and create an issue -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Chore (refactoring code, technical debt, workflow improvements)
- [X] Enhancement (small improvements)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## Checklist


### Required
- [X] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [X] Self-reviewed my own code
- [X] Tested my code in a local environment
- [X] Commented on my code in hard-to-understand areas
- [X] Checked for warnings, there are none
- [X] Removed all `console.logs`
- [X] Merged the latest changes from main onto my branch with `git pull origin main`
- [X] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the UnInbox Docs if changes were necessary
