### PR TITLE
feat(web): switch avatars to not have ID

### DIFF
--- a/apps/platform/trpc/routers/contactRouter/contactRouter.ts
+++ b/apps/platform/trpc/routers/contactRouter/contactRouter.ts
@@ -21,7 +21,7 @@ export const contactsRouter = router({
         where: and(eq(contacts.orgId, orgId), eq(contacts.type, 'person')),
         columns: {
           publicId: true,
-          avatarId: true,
+          avatarTimestamp: true,
           emailUsername: true,
           emailDomain: true,
           name: true,

--- a/apps/platform/trpc/routers/convoRouter/convoRouter.ts
+++ b/apps/platform/trpc/routers/convoRouter/convoRouter.ts
@@ -1101,7 +1101,7 @@ export const convoRouter = router({
                 with: {
                   profile: {
                     columns: {
-                      avatarId: true,
+                      avatarTimestamp: true,
                       firstName: true,
                       lastName: true,
                       publicId: true,
@@ -1113,7 +1113,7 @@ export const convoRouter = router({
               },
               group: {
                 columns: {
-                  avatarId: true,
+                  avatarTimestamp: true,
                   id: true,
                   name: true,
                   color: true,
@@ -1130,7 +1130,7 @@ export const convoRouter = router({
               },
               contact: {
                 columns: {
-                  avatarId: true,
+                  avatarTimestamp: true,
                   publicId: true,
                   name: true,
                   emailUsername: true,
@@ -1285,7 +1285,7 @@ export const convoRouter = router({
                       publicId: true,
                       firstName: true,
                       lastName: true,
-                      avatarId: true,
+                      avatarTimestamp: true,
                       handle: true
                     }
                   }
@@ -1296,14 +1296,14 @@ export const convoRouter = router({
                   publicId: true,
                   name: true,
                   color: true,
-                  avatarId: true
+                  avatarTimestamp: true
                 }
               },
               contact: {
                 columns: {
                   publicId: true,
                   name: true,
-                  avatarId: true,
+                  avatarTimestamp: true,
                   setName: true,
                   emailUsername: true,
                   emailDomain: true,
@@ -1335,7 +1335,7 @@ export const convoRouter = router({
                           publicId: true,
                           firstName: true,
                           lastName: true,
-                          avatarId: true,
+                          avatarTimestamp: true,
                           handle: true
                         }
                       }
@@ -1346,14 +1346,14 @@ export const convoRouter = router({
                       publicId: true,
                       name: true,
                       color: true,
-                      avatarId: true
+                      avatarTimestamp: true
                     }
                   },
                   contact: {
                     columns: {
                       publicId: true,
                       name: true,
-                      avatarId: true,
+                      avatarTimestamp: true,
                       setName: true,
                       emailUsername: true,
                       emailDomain: true,

--- a/apps/platform/trpc/routers/orgRouter/mail/emailIdentityRouter.ts
+++ b/apps/platform/trpc/routers/orgRouter/mail/emailIdentityRouter.ts
@@ -361,7 +361,7 @@ export const emailIdentityRouter = router({
                     profile: {
                       columns: {
                         publicId: true,
-                        avatarId: true,
+                        avatarTimestamp: true,
                         firstName: true,
                         lastName: true,
                         handle: true,
@@ -392,7 +392,7 @@ export const emailIdentityRouter = router({
                     group: {
                       columns: {
                         publicId: true,
-                        avatarId: true,
+                        avatarTimestamp: true,
                         name: true,
                         description: true,
                         color: true
@@ -403,7 +403,7 @@ export const emailIdentityRouter = router({
                         profile: {
                           columns: {
                             publicId: true,
-                            avatarId: true,
+                            avatarTimestamp: true,
                             firstName: true,
                             lastName: true,
                             handle: true,

--- a/apps/platform/trpc/routers/orgRouter/orgCrudRouter.ts
+++ b/apps/platform/trpc/routers/orgRouter/orgCrudRouter.ts
@@ -164,7 +164,7 @@ export const crudRouter = router({
           org: {
             columns: {
               publicId: true,
-              avatarId: true,
+              avatarTimestamp: true,
               name: true,
               slug: true
             }

--- a/apps/platform/trpc/routers/orgRouter/setup/profileRouter.ts
+++ b/apps/platform/trpc/routers/orgRouter/setup/profileRouter.ts
@@ -27,7 +27,7 @@ export const orgProfileRouter = router({
       const orgProfileQuery = await db.query.orgs.findFirst({
         columns: {
           publicId: true,
-          avatarId: true,
+          avatarTimestamp: true,
           name: true
         },
         where: orgPublicId ? eq(orgs.publicId, orgPublicId) : eq(orgs.id, orgId)

--- a/apps/platform/trpc/routers/orgRouter/users/groupsRouter.ts
+++ b/apps/platform/trpc/routers/orgRouter/users/groupsRouter.ts
@@ -65,7 +65,7 @@ export const groupsRouter = router({
       const groupQuery = await db.query.groups.findMany({
         columns: {
           publicId: true,
-          avatarId: true,
+          avatarTimestamp: true,
           name: true,
           description: true,
           color: true
@@ -86,7 +86,7 @@ export const groupsRouter = router({
               orgMemberProfile: {
                 columns: {
                   publicId: true,
-                  avatarId: true,
+                  avatarTimestamp: true,
                   firstName: true,
                   lastName: true,
                   handle: true,
@@ -125,7 +125,7 @@ export const groupsRouter = router({
       const groupQuery = await dbReplica.query.groups.findFirst({
         columns: {
           publicId: true,
-          avatarId: true,
+          avatarTimestamp: true,
           name: true,
           description: true,
           color: true
@@ -150,7 +150,7 @@ export const groupsRouter = router({
               orgMemberProfile: {
                 columns: {
                   publicId: true,
-                  avatarId: true,
+                  avatarTimestamp: true,
                   firstName: true,
                   lastName: true,
                   handle: true,

--- a/apps/platform/trpc/routers/orgRouter/users/invitesRouter.ts
+++ b/apps/platform/trpc/routers/orgRouter/users/invitesRouter.ts
@@ -221,7 +221,7 @@ export const invitesRouter = router({
               profile: {
                 columns: {
                   publicId: true,
-                  avatarId: true,
+                  avatarTimestamp: true,
                   firstName: true,
                   lastName: true
                 }
@@ -233,7 +233,7 @@ export const invitesRouter = router({
               profile: {
                 columns: {
                   publicId: true,
-                  avatarId: true,
+                  avatarTimestamp: true,
                   firstName: true,
                   lastName: true
                 }
@@ -270,7 +270,7 @@ export const invitesRouter = router({
           org: {
             columns: {
               publicId: true,
-              avatarId: true,
+              avatarTimestamp: true,
               name: true,
               slug: true
             }
@@ -303,7 +303,7 @@ export const invitesRouter = router({
       return {
         valid: true,
         orgPublicId: queryInvitesResponse.org.publicId,
-        orgAvatarId: queryInvitesResponse.org.avatarId,
+        orgAvatarTimestamp: queryInvitesResponse.org.avatarTimestamp,
         orgName: queryInvitesResponse.org.name,
         orgSlug: queryInvitesResponse.org.slug,
         loggedIn: userLoggedIn

--- a/apps/platform/trpc/routers/orgRouter/users/membersRouter.ts
+++ b/apps/platform/trpc/routers/orgRouter/users/membersRouter.ts
@@ -36,7 +36,7 @@ export const orgMembersRouter = router({
               profile: {
                 columns: {
                   publicId: true,
-                  avatarId: true,
+                  avatarTimestamp: true,
                   firstName: true,
                   lastName: true,
                   handle: true,
@@ -95,7 +95,7 @@ export const orgMembersRouter = router({
               profile: {
                 columns: {
                   publicId: true,
-                  avatarId: true,
+                  avatarTimestamp: true,
                   firstName: true,
                   lastName: true,
                   title: true,

--- a/apps/platform/trpc/routers/userRouter/addressRouter.ts
+++ b/apps/platform/trpc/routers/userRouter/addressRouter.ts
@@ -39,7 +39,7 @@ export const addressRouter = router({
             org: {
               columns: {
                 publicId: true,
-                avatarId: true,
+                avatarTimestamp: true,
                 name: true,
                 slug: true
               }

--- a/apps/platform/trpc/routers/userRouter/profileRouter.ts
+++ b/apps/platform/trpc/routers/userRouter/profileRouter.ts
@@ -92,7 +92,7 @@ export const profileRouter = router({
           profile: {
             columns: {
               publicId: true,
-              avatarId: true,
+              avatarTimestamp: true,
               firstName: true,
               lastName: true,
               handle: true,

--- a/apps/storage/api/avatar.post.ts
+++ b/apps/storage/api/avatar.post.ts
@@ -35,7 +35,7 @@ export default eventHandler({
 
     const formInputs = await readMultipartFormData(event);
 
-    const avatarId = nanoIdLong();
+    const newAvatarTimestamp = new Date();
 
     if (!formInputs) {
       setResponseStatus(event, 400);
@@ -70,7 +70,7 @@ export default eventHandler({
         columns: {
           id: true,
           accountId: true,
-          avatarId: true
+          avatarTimestamp: true
         }
       });
       if (!profileResponse || !profileResponse.accountId) {
@@ -90,7 +90,7 @@ export default eventHandler({
         columns: {
           id: true,
           slug: true,
-          avatarId: true
+          avatarTimestamp: true
         },
         with: {
           members: {
@@ -124,7 +124,7 @@ export default eventHandler({
         where: eq(groups.publicId, publicId),
         columns: {
           id: true,
-          avatarId: true
+          avatarTimestamp: true
         },
         with: {
           org: {
@@ -188,7 +188,7 @@ export default eventHandler({
         .toBuffer();
       const command = new PutObjectCommand({
         Bucket: s3Config.bucketAvatars,
-        Key: `${typeObject.value}_${avatarId}/${size.name}`,
+        Key: `${publicId}/${size.name}`,
         Body: resizedImage,
         ContentType: file.type
       });
@@ -202,7 +202,7 @@ export default eventHandler({
       await db
         .update(orgMemberProfiles)
         .set({
-          avatarId: avatarId
+          avatarTimestamp: newAvatarTimestamp
         })
         .where(eq(orgMemberProfiles.publicId, publicId));
     } else if (typeObject.name === 'org') {
@@ -212,7 +212,7 @@ export default eventHandler({
       await db
         .update(orgs)
         .set({
-          avatarId: avatarId
+          avatarTimestamp: newAvatarTimestamp
         })
         .where(eq(orgs.publicId, publicId));
     } else if (typeObject.name === 'group') {
@@ -222,7 +222,7 @@ export default eventHandler({
       await db
         .update(groups)
         .set({
-          avatarId: avatarId
+          avatarTimestamp: newAvatarTimestamp
         })
         .where(eq(groups.publicId, publicId));
     } else if (typeObject.name === 'contact') {
@@ -232,11 +232,11 @@ export default eventHandler({
       await db
         .update(contacts)
         .set({
-          avatarId: avatarId
+          avatarTimestamp: newAvatarTimestamp
         })
         .where(eq(contacts.publicId, publicId));
     }
 
-    return { avatarId: avatarId };
+    return { avatarTimestamp: newAvatarTimestamp };
   }
 });

--- a/apps/web-app/components/convos/convoAvatar.vue
+++ b/apps/web-app/components/convos/convoAvatar.vue
@@ -11,8 +11,8 @@
 <template>
   <UnUiAvatar
     v-if="props.participant"
-    :avatar-id="props.participant.avatarPublicId"
-    :public-id="props.participant.avatarPublicId"
+    :public-id="props.participant.avatarProfilePublicId"
+    :avatar-timestamp="props.participant.avatarTimestamp"
     :alt="props.participant.name"
     :type="props.participant.type"
     :color="props.participant.color"

--- a/apps/web-app/components/convos/convoListItem.vue
+++ b/apps/web-app/components/convos/convoListItem.vue
@@ -40,25 +40,9 @@
   });
 
   for (const participant of props.convo.participants) {
-    const {
-      participantPublicId,
-      participantTypePublicId,
-      avatarPublicId,
-      participantName,
-      participantType,
-      participantColor,
-      participantRole
-    } = useUtils().convos.useParticipantData(participant);
-    const participantData: ConvoParticipantEntry = {
-      participantPublicId: participantPublicId,
-      typePublicId: participantTypePublicId,
-      avatarPublicId: avatarPublicId,
-      name: participantName,
-      type: participantType,
-      role: participantRole,
-      color: participantColor
-    };
-    if (participantTypePublicId === authorEntryPublicId.value) {
+    const participantData = useUtils().convos.useParticipantData(participant);
+    if (!participantData) continue;
+    if (participantData?.typePublicId === authorEntryPublicId.value) {
       author.value = participantData;
     } else {
       participantArray.value.push(participantData);

--- a/apps/web-app/components/convos/convoMessageItem.vue
+++ b/apps/web-app/components/convos/convoMessageItem.vue
@@ -74,7 +74,7 @@
         v-if="author"
         class="flex flex-row items-center gap-1">
         <UnUiAvatar
-          :public-id="author.publicId"
+          :public-id="author.avatarProfilePublicId"
           :avatar-timestamp="author.avatarTimestamp"
           :alt="author.name"
           :type="author.type"

--- a/apps/web-app/components/convos/convoMessageItem.vue
+++ b/apps/web-app/components/convos/convoMessageItem.vue
@@ -75,7 +75,7 @@
         class="flex flex-row items-center gap-1">
         <UnUiAvatar
           :public-id="author.publicId"
-          :avatar-id="author.avatarPublicId"
+          :avatar-timestamp="author.avatarTimestamp"
           :alt="author.name"
           :type="author.type"
           :color="author.color"

--- a/apps/web-app/components/layout/navbar.vue
+++ b/apps/web-app/components/layout/navbar.vue
@@ -123,7 +123,7 @@
     slot: 'org';
     label: string;
     publicId: string;
-    avatarId: string | null;
+    avatarTimestamp: Date | null;
     slug: string;
     click: () => void;
   }
@@ -137,7 +137,7 @@
           slot: 'org',
           label: org.org.name,
           publicId: org.org.publicId,
-          avatarId: org.org.avatarId,
+          avatarTimestamp: org.org.avatarTimestamp,
           slug: org.org.slug,
           click: () => {
             navigateTo(`/${org.org.slug}`);
@@ -312,8 +312,9 @@
         class="flex w-full max-w-[240px] flex-row items-center justify-between gap-2 p-2">
         <div class="flex w-full flex-row items-center gap-2 overflow-hidden">
           <UnUiAvatar
-            :public-id="currentOrgProfile?.publicId || ''"
-            :avatar-id="currentOrgProfile?.avatarId || ''"
+            v-if="currentOrgProfile"
+            :public-id="currentOrgProfile?.publicId"
+            :avatar-timestamp="currentOrgProfile?.avatarTimestamp || null"
             :type="'org'"
             :alt="currentOrgProfile?.name"
             size="xs" />
@@ -326,8 +327,11 @@
           <p>Signed in as</p>
           <div class="flex w-full flex-row items-center gap-2 overflow-hidden">
             <UnUiAvatar
-              :public-id="orgMemberProfile?.profile?.publicId || ''"
-              :avatar-id="orgMemberProfile?.profile?.avatarId || ''"
+              v-if="orgMemberProfile"
+              :public-id="orgMemberProfile?.profile?.publicId"
+              :avatar-timestamp="
+                orgMemberProfile?.profile?.avatarTimestamp || null
+              "
               :type="'orgMember'"
               :alt="
                 orgMemberProfile?.profile?.firstName +
@@ -346,7 +350,7 @@
         <div class="flex max-w-full flex-row items-center gap-2">
           <UnUiAvatar
             :public-id="item.publicId"
-            :avatar-id="item.avatarId"
+            :avatar-timestamp="item.avatarTimestamp"
             :type="'org'"
             :alt="item.label"
             size="sm" />

--- a/apps/web-app/components/settings/addNewEmail.vue
+++ b/apps/web-app/components/settings/addNewEmail.vue
@@ -10,6 +10,7 @@
     watchDebounced
   } from '#imports';
   import { useEE } from '~/composables/EE';
+  import type { TypeId } from '@u22n/utils';
 
   const { $trpc } = useNuxtApp();
 
@@ -79,8 +80,8 @@
       { server: false }
     );
   interface OrgUserGroups {
-    publicId: String;
-    avatarId: String;
+    publicId: TypeId<'groups'>;
+    avatarTimestamp: Date | null;
     name: String;
     description: String | null;
     color: String | null;
@@ -92,7 +93,7 @@
       for (const group of newOrgUserGroupsData.groups) {
         orgUserGroups.value.push({
           publicId: group.publicId,
-          avatarId: group.avatarId || '',
+          avatarTimestamp: group.avatarTimestamp,
           name: group.name,
           description: group.description,
           color: group.color
@@ -110,8 +111,9 @@
       { server: false }
     );
   interface OrgMembers {
-    publicId: String;
-    avatarId: String;
+    publicId: TypeId<'orgMembers'>;
+    profilePublicId: TypeId<'orgMemberProfile'>;
+    avatarTimestamp: Date | null;
     name: String;
     handle: String;
     title: String | null;
@@ -124,7 +126,8 @@
       for (const member of newOrgMembersData.members) {
         orgMembers.value.push({
           publicId: member.publicId,
-          avatarId: member.profile?.avatarId || '',
+          profilePublicId: member.profile?.publicId,
+          avatarTimestamp: member.profile?.avatarTimestamp,
           name:
             member.profile?.firstName + ' ' + member.profile?.lastName || '',
           handle: member.profile?.handle || '',
@@ -381,8 +384,8 @@
                       class="flex flex-row items-center gap-1 truncate">
                       <UnUiAvatar
                         :alt="group.name.toString()"
-                        :public-id="group.publicId?.toString()"
-                        :avatar-id="group.avatarId?.toString()"
+                        :public-id="group.publicId"
+                        :avatar-timestamp="group.avatarTimestamp"
                         :type="'group'"
                         :color="group.color as UiColor"
                         size="3xs" />
@@ -394,7 +397,7 @@
                 <template #option="{ option }">
                   <UnUiAvatar
                     :public-id="option.publicId"
-                    :avatar-id="option.avatarId"
+                    :avatar-timestamp="option.avatarTimestamp"
                     :type="'group'"
                     :alt="option.name"
                     :color="option.color as UiColor"
@@ -434,9 +437,10 @@
                       :key="index"
                       class="flex flex-row items-center gap-1 truncate">
                       <UnUiAvatar
+                        v-if="member.publicId"
+                        :public-id="member.profilePublicId"
                         :alt="member.name.toString()"
-                        :public-id="member.publicId?.toString()"
-                        :avatar-id="member.avatarId?.toString()"
+                        :avatar-timestamp="member.avatarTimestamp"
                         :type="'orgMember'"
                         size="3xs" />
                       <span>{{ member.name }}</span>
@@ -447,7 +451,7 @@
                 <template #option="{ option }">
                   <UnUiAvatar
                     :public-id="option.publicId"
-                    :avatar-id="option.avatarId"
+                    :avatar-timestamp="option.avatarTimestamp"
                     :type="'orgMember'"
                     :alt="option.name"
                     size="xs" />

--- a/apps/web-app/components/settings/addNewInvite.vue
+++ b/apps/web-app/components/settings/addNewInvite.vue
@@ -8,6 +8,7 @@
     watchDebounced
   } from '#imports';
   import type { UiColor } from '@u22n/types/ui';
+  import type { TypeId } from '@u22n/utils';
   import { z } from 'zod';
 
   const { $trpc } = useNuxtApp();
@@ -157,8 +158,8 @@
       { server: false }
     );
   interface OrgUserGroups {
-    publicId: String;
-    avatarId: String;
+    publicId: TypeId<'groups'>;
+    avatarTimestamp: Date | null;
     name: String;
     description: String | null;
     color: String | null;
@@ -170,7 +171,7 @@
       for (const group of newOrgGroupsData.groups) {
         orgUserGroups.value.push({
           publicId: group.publicId,
-          avatarId: group.avatarId || '',
+          avatarTimestamp: group.avatarTimestamp,
           name: group.name,
           description: group.description,
           color: group.color
@@ -485,8 +486,8 @@
                 class="flex flex-row items-center gap-1 truncate">
                 <UnUiAvatar
                   :alt="group.name.toString()"
-                  :public-id="group.publicId?.toString()"
-                  :avatar-id="group.avatarId?.toString()"
+                  :public-id="group.publicId"
+                  :avatar-timestamp="group.avatarTimestamp"
                   :type="'group'"
                   :color="group.color as UiColor"
                   size="3xs" />
@@ -498,7 +499,7 @@
           <template #option="{ option }">
             <UnUiAvatar
               :public-id="option.publicId"
-              :avatar-id="option.avatarId"
+              :avatar-timestamp="option.avatarTimestamp"
               :type="'group'"
               :alt="option.name"
               :color="option.color.toString()"

--- a/apps/web-app/components/settings/invitesItem.vue
+++ b/apps/web-app/components/settings/invitesItem.vue
@@ -25,8 +25,8 @@
     return props.inviteData.invitedByOrgMember.profile.publicId;
   });
 
-  const inviterAvatarId = computed(() => {
-    return props.inviteData.invitedByOrgMember.profile.avatarId;
+  const inviterAvatarTimestamp = computed(() => {
+    return props.inviteData.invitedByOrgMember.profile.avatarTimestamp;
   });
 
   const inviteeName = computed(() => {
@@ -42,9 +42,9 @@
       : null;
   });
 
-  const inviteeAvatarId = computed(() => {
+  const inviteeAvatarTimestamp = computed(() => {
     return props.inviteData.orgMember
-      ? props.inviteData.orgMember.profile.avatarId
+      ? props.inviteData.orgMember.profile.avatarTimestamp
       : null;
   });
 </script>
@@ -97,7 +97,7 @@
             <div class="flex flex-row items-center gap-2">
               <UnUiAvatar
                 :public-id="inviteePublicId"
-                :avatar-id="inviteeAvatarId"
+                :avatar-timestamp="inviteeAvatarTimestamp"
                 :type="'orgMember'"
                 :size="'md'"
                 :alt="inviteeName" />
@@ -127,7 +127,7 @@
             <div class="flex flex-row items-center gap-2">
               <UnUiAvatar
                 :public-id="inviterPublicId"
-                :avatar-id="inviterAvatarId"
+                :avatar-timestamp="inviterAvatarTimestamp"
                 :type="'orgMember'"
                 :size="'md'"
                 :alt="inviterName" />

--- a/apps/web-app/components/un/ui-avatar-plus.vue
+++ b/apps/web-app/components/un/ui-avatar-plus.vue
@@ -29,8 +29,8 @@
   <div class="z-20 flex h-fit flex-row items-end">
     <UnUiAvatar
       v-if="primaryAvatar"
-      :avatar-id="primaryAvatar.avatarPublicId"
-      :public-id="primaryAvatar.participantPublicId"
+      :public-id="primaryAvatar.avatarProfilePublicId"
+      :avatar-timestamp="primaryAvatar.avatarTimestamp"
       :alt="primaryAvatar.name"
       :type="primaryAvatar.type"
       :color="primaryAvatar.color"
@@ -51,8 +51,8 @@
             v-for="avatar in avatarArray"
             :key="avatar.participantPublicId">
             <UnUiAvatar
-              :avatar-id="avatar.avatarPublicId"
-              :public-id="avatar.participantPublicId"
+              :public-id="avatar.avatarProfilePublicId"
+              :avatar-timestamp="avatar.avatarTimestamp"
               :alt="avatar.name"
               :type="avatar.type"
               :color="avatar.color"

--- a/apps/web-app/components/un/ui-avatar.vue
+++ b/apps/web-app/components/un/ui-avatar.vue
@@ -3,6 +3,7 @@
   import { useUtils } from '~/composables/utils';
   import { NuxtUiAvatar } from '#components';
   import { uiColors } from '@u22n/types/ui';
+  import type { TypeId } from '@u22n/utils';
 
   type UiColors = (typeof uiColors)[number] | null;
 
@@ -10,7 +11,8 @@
 
   type Props = {
     color?: UiColors;
-    avatarId: string | null;
+    publicId: TypeId<'orgMemberProfile' | 'contacts' | 'groups' | 'org'> | null;
+    avatarTimestamp: Date | null;
     name?: string;
     alt?: string;
     type: 'orgMember' | 'org' | 'group' | 'contact';
@@ -80,11 +82,19 @@
   });
 
   const avatarUrl = computed(() => {
-    return props.avatarUrl
-      ? props.avatarUrl
-      : props.avatarId
-        ? useUtils().generateAvatarUrl(props.type, props.avatarId, size.value)
-        : undefined;
+    if (props.avatarUrl) {
+      return props.avatarUrl;
+    }
+    if (props.avatarTimestamp && props.publicId) {
+      return (
+        useUtils().generateAvatarUrl({
+          publicId: props.publicId,
+          avatarTimestamp: props.avatarTimestamp,
+          size: size.value
+        }) || false
+      );
+    }
+    return false;
   });
 
   const tooltipText = computed(() => {

--- a/apps/web-app/components/un/ui-avatar.vue
+++ b/apps/web-app/components/un/ui-avatar.vue
@@ -130,7 +130,7 @@
     </template>
     <NuxtUiAvatar
       :size="size"
-      :alt="altText"
+      :alt="altText.toUpperCase()"
       :src="avatarUrl"
       :ui="{
         text: 'font-display text-white dark:text-white',

--- a/apps/web-app/composables/types.ts
+++ b/apps/web-app/composables/types.ts
@@ -1,5 +1,6 @@
 import { useNuxtApp } from '#imports';
 import { uiColors } from '@u22n/types/ui';
+import type { TypeId } from '@u22n/utils';
 
 const { $trpc } = useNuxtApp();
 
@@ -18,9 +19,10 @@ export type ConvoAttachmentUpload = {
 };
 
 export type ConvoParticipantEntry = {
-  participantPublicId: string;
-  typePublicId: string;
-  avatarPublicId: string;
+  participantPublicId: TypeId<'convoParticipants'>;
+  typePublicId: TypeId<'orgMembers' | 'groups' | 'contacts'>;
+  avatarProfilePublicId: TypeId<'orgMemberProfile' | 'groups' | 'contacts'>;
+  avatarTimestamp: Date | null;
   name: string;
   type: 'orgMember' | 'group' | 'contact';
   role:

--- a/apps/web-app/composables/utils.ts
+++ b/apps/web-app/composables/utils.ts
@@ -27,7 +27,7 @@ function generateAvatarUrl({
   if (!avatarTimestamp) {
     return null;
   }
-  const epochTs = Math.floor(avatarTimestamp.getTime() / 1000);
+  const epochTs = avatarTimestamp.getTime() / 1000;
   //@ts-ignore
   const storageBaseUrl = useRuntimeConfig().public.storageUrl;
 
@@ -59,11 +59,11 @@ function useParticipantData(
       participant.contact?.avatarTimestamp ||
       null,
     name:
+      participant.group?.name ||
+      participant.contact?.name ||
       participant.orgMember?.profile.firstName +
         ' ' +
         participant.orgMember?.profile.lastName ||
-      participant.group?.name ||
-      participant.contact?.name ||
       '',
     color: participant.group?.color || null,
     type: participant.orgMember

--- a/apps/web-app/composables/utils.ts
+++ b/apps/web-app/composables/utils.ts
@@ -1,11 +1,17 @@
+import type { ConvoParticipantEntry } from './types';
 import { cva, type VariantProps } from 'class-variance-authority';
 import type { UserConvosDataType } from '~/composables/types';
 import { useRuntimeConfig } from '#imports';
+import type { TypeId } from '@u22n/utils';
 
-function generateAvatarUrl(
-  type: 'orgMember' | 'org' | 'group' | 'contact',
-  avatarId: string,
-  size:
+function generateAvatarUrl({
+  publicId,
+  avatarTimestamp,
+  size
+}: {
+  publicId: TypeId<'orgMemberProfile' | 'contacts' | 'groups' | 'org'>;
+  avatarTimestamp: Date | null;
+  size?:
     | '3xs'
     | '2xs'
     | 'xs'
@@ -16,90 +22,60 @@ function generateAvatarUrl(
     | '2xl'
     | '3xl'
     | '4xl'
-    | '5xl'
-    | undefined
-) {
-  const types = [
-    { name: 'orgMember', value: 'om' },
-    { name: 'org', value: 'o' },
-    { name: 'contact', value: 'c' },
-    { name: 'group', value: 'g' }
-  ];
-  const typeObject = types.find((t) => t.name === type);
-  if (!typeObject) {
-    return undefined;
+    | '5xl';
+}) {
+  if (!avatarTimestamp) {
+    return null;
   }
+  const epochTs = Math.floor(avatarTimestamp.getTime() / 1000);
   //@ts-ignore
   const storageBaseUrl = useRuntimeConfig().public.storageUrl;
 
-  return `${storageBaseUrl}/avatar/${typeObject.value}_${avatarId}/${
+  return `${storageBaseUrl}/avatar/${publicId}/${
     size ? size : '5xl'
-  }`;
+  }?t=${epochTs}`;
 }
 
 function useParticipantData(
   participant: UserConvosDataType[number]['participants'][0]
 ) {
-  const {
-    publicId: participantPublicId,
-    contact,
-    group,
-    orgMember,
-    role: participantRole
-  } = participant;
+  const typePublicId =
+    participant.orgMember?.publicId ||
+    participant.group?.publicId ||
+    participant.contact?.publicId;
+  const avatarProfilePublicId =
+    participant.orgMember?.profile.publicId ||
+    participant.group?.publicId ||
+    participant.contact?.publicId;
+  if (!typePublicId || !avatarProfilePublicId) return null;
 
-  let participantType: 'orgMember' | 'group' | 'contact',
-    participantTypePublicId,
-    avatarPublicId,
-    participantName,
-    participantColor,
-    participantSignaturePlainText,
-    participantSignatureHtml;
-
-  switch (true) {
-    case !!contact?.publicId:
-      participantType = 'contact';
-      participantTypePublicId = contact.publicId;
-      avatarPublicId = contact.avatarId || '';
-      participantName =
-        contact.name || `${contact.emailUsername}@${contact.emailDomain}`;
-      participantColor = null;
-      participantSignaturePlainText = contact.signaturePlainText;
-      participantSignatureHtml = contact.signatureHtml;
-      break;
-    case !!group?.name:
-      participantType = 'group';
-      participantTypePublicId = group.publicId;
-      avatarPublicId = group.avatarId || '';
-      participantName = group.name;
-      participantColor = group.color;
-      break;
-    case !!orgMember?.publicId:
-      participantType = 'orgMember';
-      participantTypePublicId = orgMember.publicId;
-      avatarPublicId = orgMember.profile.avatarId || '';
-      participantName = `${orgMember.profile.firstName} ${orgMember.profile.lastName}`;
-      participantColor = null;
-      break;
-    default:
-      participantType = 'orgMember';
-      participantTypePublicId = '';
-      avatarPublicId = '';
-      participantName = '';
-      participantColor = null;
-  }
-
-  return {
-    participantPublicId,
-    participantType,
-    participantTypePublicId,
-    avatarPublicId,
-    participantName,
-    participantColor,
-    participantRole,
-    participantSignaturePlainText,
-    participantSignatureHtml
+  const participantData: ConvoParticipantEntry = {
+    participantPublicId: participant.publicId,
+    typePublicId: typePublicId,
+    avatarProfilePublicId: avatarProfilePublicId,
+    avatarTimestamp:
+      participant.orgMember?.profile.avatarTimestamp ||
+      participant.group?.avatarTimestamp ||
+      participant.contact?.avatarTimestamp ||
+      null,
+    name:
+      participant.orgMember?.profile.firstName +
+        ' ' +
+        participant.orgMember?.profile.lastName ||
+      participant.group?.name ||
+      participant.contact?.name ||
+      '',
+    color: participant.group?.color || null,
+    type: participant.orgMember
+      ? 'orgMember'
+      : participant.group
+        ? 'group'
+        : 'contact',
+    role: participant.role,
+    signatureHtml: participant.contact?.signatureHtml || null,
+    signaturePlainText: participant.contact?.signaturePlainText || null
   };
+  return participantData;
 }
 
 export const useUtils = () => {

--- a/apps/web-app/pages/[orgSlug]/convo/[id].vue
+++ b/apps/web-app/pages/[orgSlug]/convo/[id].vue
@@ -133,28 +133,8 @@
 
     const convoParticipants = convoDetails.value?.data?.participants || [];
     for (const participant of convoParticipants) {
-      const {
-        participantPublicId,
-        participantTypePublicId,
-        avatarPublicId,
-        participantName,
-        participantType,
-        participantColor,
-        // participantRole,
-        participantSignaturePlainText,
-        participantSignatureHtml
-      } = useUtils().convos.useParticipantData(participant);
-      const participantData: ConvoParticipantEntry = {
-        participantPublicId: participantPublicId,
-        typePublicId: participantTypePublicId,
-        avatarPublicId: avatarPublicId,
-        name: participantName,
-        type: participantType,
-        role: participant.role,
-        color: participantColor,
-        signaturePlainText: participantSignaturePlainText,
-        signatureHtml: participantSignatureHtml
-      };
+      const participantData = useUtils().convos.useParticipantData(participant);
+      if (!participantData) continue;
 
       participantArray.value.push(participantData);
       if (participant.role === 'assigned')

--- a/apps/web-app/pages/[orgSlug]/settings/org/index.vue
+++ b/apps/web-app/pages/[orgSlug]/settings/org/index.vue
@@ -87,7 +87,7 @@
     if (response.avatarTimestamp) {
       imageUrl.value = useUtils().generateAvatarUrl({
         publicId: orgPublicId,
-        avatarTimestamp: response.avatarTimestamp,
+        avatarTimestamp: new Date(),
         size: '5xl'
       }) as string;
     }
@@ -164,7 +164,7 @@
               <UnUiIcon
                 :name="
                   uploadLoading
-                    ? 'i-svg-spinners:3-dots-fade'
+                    ? 'i-svg-spinners-3-dots-fade'
                     : 'i-ph-image-square'
                 "
                 size="100%" />

--- a/apps/web-app/pages/[orgSlug]/settings/org/index.vue
+++ b/apps/web-app/pages/[orgSlug]/settings/org/index.vue
@@ -32,12 +32,12 @@
   watch(initialOrgProfile, (newVal) => {
     if (newVal && newVal.orgProfile) {
       orgNameValue.value = newVal.orgProfile.name;
-      newVal.orgProfile.avatarId
-        ? ((imageUrl.value = useUtils().generateAvatarUrl(
-            'org',
-            newVal.orgProfile.avatarId,
-            '5xl'
-          )) as string)
+      newVal.orgProfile.avatarTimestamp
+        ? (imageUrl.value = useUtils().generateAvatarUrl({
+            publicId: newVal.orgProfile.publicId,
+            avatarTimestamp: newVal.orgProfile.avatarTimestamp,
+            size: '5xl'
+          }))
         : null;
     }
   });
@@ -68,6 +68,8 @@
     openFileDialog();
   }
   selectedFilesOnChange(async (selectedFiles: any) => {
+    const orgPublicId = initialOrgProfile.value?.orgProfile.publicId;
+    if (!orgPublicId) return;
     uploadLoading.value = true;
     if (!selectedFiles) return;
     const formData = new FormData();
@@ -75,22 +77,19 @@
     const storageUrl = useRuntimeConfig().public.storageUrl as string;
     formData.append('file', selectedFiles[0]);
     formData.append('type', 'org');
-    formData.append(
-      'publicId',
-      initialOrgProfile.value?.orgProfile.publicId || ''
-    );
+    formData.append('publicId', orgPublicId);
     const response = (await $fetch(`${storageUrl}/api/avatar`, {
       method: 'post',
       body: formData,
       credentials: 'include'
     })) as any;
 
-    if (response.avatarId) {
-      imageUrl.value = useUtils().generateAvatarUrl(
-        'org',
-        response.avatarId,
-        '5xl'
-      ) as string;
+    if (response.avatarTimestamp) {
+      imageUrl.value = useUtils().generateAvatarUrl({
+        publicId: orgPublicId,
+        avatarTimestamp: response.avatarTimestamp,
+        size: '5xl'
+      }) as string;
     }
     refreshNuxtData('getAccountOrgsNav');
     uploadLoading.value = false;

--- a/apps/web-app/pages/[orgSlug]/settings/org/mail/addresses/[emailIdentityId].vue
+++ b/apps/web-app/pages/[orgSlug]/settings/org/mail/addresses/[emailIdentityId].vue
@@ -78,12 +78,12 @@
               ?.routingRules.destinations"
             :key="destination.id">
             <div
-              v-if="destination.groupId"
+              v-if="destination.groupId && destination.group"
               class="bg-base-2 flex flex-row items-center gap-8 rounded-xl p-2">
               <div class="flex flex-row items-center gap-4">
                 <UnUiAvatar
-                  :public-id="destination.group?.publicId || ''"
-                  :avatar-id="destination.group?.avatarId || ''"
+                  :public-id="destination.group?.publicId"
+                  :avatar-timestamp="destination.group?.avatarTimestamp"
                   :type="'group'"
                   :alt="destination.group?.name"
                   :color="destination.group?.color as UiColor"
@@ -101,12 +101,14 @@
             </div>
 
             <div
-              v-if="destination.orgMemberId"
+              v-if="destination.orgMemberId && destination.orgMember?.profile"
               class="bg-base-2 flex flex-row items-center gap-8 rounded-xl p-2">
               <div class="flex flex-row items-center gap-4">
                 <UnUiAvatar
-                  :public-id="destination.orgMember?.profile?.publicId || ''"
-                  :avatar-id="destination.orgMember?.profile?.avatarId || ''"
+                  :public-id="destination.orgMember?.profile?.publicId"
+                  :avatar-timestamp="
+                    destination.orgMember?.profile?.avatarTimestamp
+                  "
                   :type="'orgMember'"
                   :alt="
                     destination.orgMember?.profile?.firstName +

--- a/apps/web-app/pages/[orgSlug]/settings/org/users/groups/index.vue
+++ b/apps/web-app/pages/[orgSlug]/settings/org/users/groups/index.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
   import { navigateTo, ref, useNuxtApp, useRoute, watch } from '#imports';
+  import type { TypeId } from '@u22n/utils';
 
   const { $trpc } = useNuxtApp();
   const orgSlug = useRoute().params.orgSlug as string;
@@ -33,18 +34,21 @@
   ];
 
   interface TableRow {
-    publicId: string;
-    avatarId: string;
+    publicId: TypeId<'groups'>;
+    avatarTimestamp: Date | null;
     name: string;
     description: string | null;
     color: string | null;
     members: ({
       publicId: string;
-      avatarId: string;
-      firstName: string | null;
-      lastName: string | null;
-      handle: string | null;
-      title: string | null;
+      orgMemberProfile: {
+        publicId: TypeId<'orgMemberProfile'>;
+        avatarTimestamp: Date | null;
+        firstName: string | null;
+        lastName: string | null;
+        handle: string | null;
+        title: string | null;
+      };
     } | null)[];
   }
 
@@ -55,7 +59,7 @@
       for (const group of newResults.groups) {
         tableRows.value.push({
           publicId: group.publicId,
-          avatarId: group.avatarId || '',
+          avatarTimestamp: group.avatarTimestamp,
           name: group.name,
           description: group.description,
           color: group.color,
@@ -110,7 +114,7 @@
           <div class="flex flex-row items-center gap-2">
             <UnUiAvatar
               :public-id="row.publicId"
-              :avatar-id="row.avatarId"
+              :avatar-timestamp="row.avatarTimestamp"
               :type="'orgMember'"
               :alt="row.name ? row.name : ''"
               :color="row.color ? row.color : ''"
@@ -126,20 +130,22 @@
               <UnUiAvatar
                 v-for="member in row.members"
                 :key="member.publicId"
-                :public-id="member.orgMember.publicId"
-                :avatar-id="member.orgMemberProfile.avatarId"
+                :public-id="member.orgMember.orgMemberProfile.publicId"
+                :avatar-timestamp="
+                  member.orgMemberProfile.orgMemberProfile.avatarTimestamp
+                "
                 :type="'orgMember'"
                 :alt="
-                  member.orgMemberProfile.firstName &&
-                  member.orgMemberProfile.lastName
-                    ? member.orgMemberProfile.firstName +
+                  member.orgMemberProfile.orgMemberProfile.firstName &&
+                  member.orgMemberProfile.orgMemberProfile.lastName
+                    ? member.orgMemberProfile.orgMemberProfile.firstName +
                       ' ' +
-                      member.orgMemberProfile.lastName
+                      member.orgMemberProfile.orgMemberProfile.lastName
                     : ''
                 "
                 :color="
-                  member.orgMemberProfile.color
-                    ? member.orgMemberProfile.color
+                  member.orgMemberProfile.orgMemberProfile.color
+                    ? member.orgMemberProfile.orgMemberProfile.color
                     : ''
                 "
                 size="xs" />

--- a/apps/web-app/pages/[orgSlug]/settings/org/users/invites/index.vue
+++ b/apps/web-app/pages/[orgSlug]/settings/org/users/invites/index.vue
@@ -88,12 +88,18 @@
             invite.invitedByOrgMember.profile.firstName +
             ' ' +
             invite.invitedByOrgMember.profile.lastName,
-          createdByAvatarId: invite.invitedByOrgMember.profile
-            ? invite.invitedByOrgMember.profile.avatarId
+          createdByOrgMemberProfilePublicId: invite.invitedByOrgMember.profile
+            ? invite.invitedByOrgMember.profile.publicId
+            : '',
+          createdByAvatarTimestamp: invite.invitedByOrgMember.profile
+            ? invite.invitedByOrgMember.profile.avatarTimestamp
             : '',
           created: invite.invitedAt,
-          orgMemberAvatarId: invite.orgMember?.profile
-            ? invite.orgMember?.profile.avatarId
+          orgMemberProfilePublicId: invite.orgMember?.profile
+            ? invite.orgMember?.profile.publicId
+            : '',
+          orgMemberAvatarTimestamp: invite.orgMember?.profile
+            ? invite.orgMember?.profile.avatarTimestamp
             : '',
           usedBy: invite.orgMember?.profile
             ? invite.orgMember?.profile.firstName +
@@ -153,8 +159,8 @@
             <div class="flex flex-row items-center gap-2">
               <UnUiAvatar
                 v-if="row.userAvatar || row.usedBy"
-                :public-id="''"
-                :avatar-id="row.orgMemberAvatarId"
+                :public-id="row.orgMemberProfilePublicId"
+                :avatar-timestamp="row.orgMemberAvatarTimestamp"
                 :type="'orgMember'"
                 :alt="row.usedBy ? row.usedBy : ''"
                 size="xs" />
@@ -185,8 +191,8 @@
           <template #createdBy-data="{ row }">
             <div class="flex flex-row items-center gap-2">
               <UnUiAvatar
-                :public-id="row.createdByAvatarId"
-                :avatar-id="row.creatorAvatarId"
+                :public-id="row.createdByOrgMemberProfilePublicId"
+                :avatar-timestamp="row.createdByAvatarTimestamp"
                 :type="'orgMember'"
                 :alt="row.createdBy ? row.createdBy : ''"
                 size="xs" />

--- a/apps/web-app/pages/[orgSlug]/settings/org/users/members/index.vue
+++ b/apps/web-app/pages/[orgSlug]/settings/org/users/members/index.vue
@@ -50,7 +50,7 @@
         tableRows.value.push({
           name: member.profile.firstName + ' ' + member.profile.lastName,
           publicId: member.profile.publicId,
-          avatarId: member.profile.avatarId || '',
+          avatarTimestamp: member.profile.avatarTimestamp,
           handle: member.profile.handle,
           title: member.profile.title,
           role: member.role,
@@ -93,7 +93,7 @@
           <div class="flex flex-row items-center gap-2">
             <UnUiAvatar
               :public-id="row.publicId"
-              :avatar-id="row.avatarId"
+              :avatar-timestamp="row.avatarTimestamp"
               :type="'orgMember'"
               :alt="row.name ? row.name : ''"
               size="xs" />

--- a/apps/web-app/pages/[orgSlug]/settings/user/addresses.vue
+++ b/apps/web-app/pages/[orgSlug]/settings/user/addresses.vue
@@ -55,7 +55,7 @@
             address: 'forwardingAddress'
           },
           org: identity.org,
-          avatarId: identity.org.avatarId,
+          avatarTimestamp: identity.org.avatarTimestamp,
           publicId: identity.emailIdentity.publicId
         });
       });
@@ -417,7 +417,7 @@
               <div class="flex flex-row items-center gap-2">
                 <UnUiAvatar
                   :public-id="row.org.publicId"
-                  :avatar-id="row.org.avatarId"
+                  :avatar-timestamp="row.org.avatarTimestamp"
                   type="org"
                   :alt="row.org.name ? row.org.name : ''"
                   size="xs" />

--- a/apps/web-app/pages/[orgSlug]/settings/user/profiles.vue
+++ b/apps/web-app/pages/[orgSlug]/settings/user/profiles.vue
@@ -96,7 +96,7 @@
     if (response.avatarTimestamp) {
       imageUrl.value = useUtils().generateAvatarUrl({
         publicId: initialAccountProfile.value?.profile.publicId,
-        avatarTimestamp: response.avatarTimestamp || new Date(),
+        avatarTimestamp: new Date(),
         size: '5xl'
       });
     }
@@ -163,7 +163,7 @@
       v-if="pending"
       class="bg-base-3 flex w-full flex-row justify-center gap-4 rounded-xl rounded-tl-2xl p-8">
       <UnUiIcon
-        name="i-svg-spinners:3-dots-fade"
+        name="i-svg-spinners-3-dots-fade"
         size="24" />
       <span>Loading your profiles</span>
     </div>
@@ -183,7 +183,7 @@
               <UnUiIcon
                 :name="
                   uploadLoading
-                    ? 'i-svg-spinners:3-dots-fade'
+                    ? 'i-svg-spinners-3-dots-fade'
                     : 'i-ph-image-square'
                 "
                 size="100%" />

--- a/apps/web-app/pages/[orgSlug]/settings/user/profiles.vue
+++ b/apps/web-app/pages/[orgSlug]/settings/user/profiles.vue
@@ -44,12 +44,12 @@
         titleValue.value = newVal.profile.title || '';
         blurbValue.value = newVal.profile.blurb || '';
 
-        if (newVal.profile.avatarId) {
-          imageUrl.value = useUtils().generateAvatarUrl(
-            'orgMember',
-            newVal.profile.avatarId,
-            '5xl'
-          );
+        if (newVal.profile.avatarTimestamp) {
+          imageUrl.value = useUtils().generateAvatarUrl({
+            publicId: newVal.profile.publicId!,
+            avatarTimestamp: newVal.profile.avatarTimestamp,
+            size: '5xl'
+          });
         }
       }
     }
@@ -78,6 +78,7 @@
   selectedFilesOnChange(async (selectedFiles) => {
     uploadLoading.value = true;
     if (!selectedFiles || !selectedFiles[0]) return;
+    if (!initialAccountProfile.value?.profile.publicId) return;
     const formData = new FormData();
     // @ts-ignore
     const storageUrl = useRuntimeConfig().public.storageUrl;
@@ -87,21 +88,17 @@
       'publicId',
       initialAccountProfile.value?.profile.publicId || ''
     );
-    formData.append(
-      'avatarId',
-      initialAccountProfile.value?.profile.avatarId || ''
-    );
     const response = (await $fetch(`${storageUrl}/api/avatar`, {
       method: 'post',
       body: formData,
       credentials: 'include'
     })) as any;
-    if (response.avatarId) {
-      imageUrl.value = useUtils().generateAvatarUrl(
-        'orgMember',
-        response.avatarId,
-        '5xl'
-      );
+    if (response.avatarTimestamp) {
+      imageUrl.value = useUtils().generateAvatarUrl({
+        publicId: initialAccountProfile.value?.profile.publicId,
+        avatarTimestamp: response.avatarTimestamp || new Date(),
+        size: '5xl'
+      });
     }
     refreshNuxtData('getOrgMemberSingleProfileNav');
     uploadLoading.value = false;

--- a/apps/web-app/pages/join/invite/[inviteId].vue
+++ b/apps/web-app/pages/join/invite/[inviteId].vue
@@ -143,8 +143,9 @@
         </h2>
         <div class="flex flex-col items-center gap-2">
           <UnUiAvatar
-            :public-id="inviteQuery?.orgPublicId || ''"
-            :avatar-id="inviteQuery?.orgAvatarId || ''"
+            v-if="inviteQuery"
+            :public-id="inviteQuery?.orgPublicId"
+            :avatar-timestamp="inviteQuery?.orgAvatarTimestamp"
             :type="'org'"
             :alt="inviteQuery?.orgName"
             size="3xl" />

--- a/apps/web-app/pages/join/profile.vue
+++ b/apps/web-app/pages/join/profile.vue
@@ -55,12 +55,12 @@
       titleValue.value = newVal.profile.title || '';
       blurbValue.value = newVal.profile.blurb || '';
 
-      if (newVal.profile.avatarId) {
-        imageUrl.value = useUtils().generateAvatarUrl(
-          'orgMember',
-          newVal.profile.avatarId,
-          '5xl'
-        ) as string;
+      if (newVal.profile.avatarTimestamp) {
+        imageUrl.value = useUtils().generateAvatarUrl({
+          publicId: newVal.profile.publicId!,
+          avatarTimestamp: newVal.profile.avatarTimestamp,
+          size: '5xl'
+        });
       }
     }
   });
@@ -86,6 +86,7 @@
   selectedFilesOnChange(async (selectedFiles) => {
     uploadLoading.value = true;
     if (!selectedFiles || !selectedFiles[0]) return;
+    if (!accountOrgProfile.value?.profile?.publicId) return;
     const formData = new FormData();
     // @ts-ignore
     const storageUrl = useRuntimeConfig().public.storageUrl;
@@ -95,21 +96,17 @@
       'publicId',
       accountOrgProfile.value?.profile?.publicId || ''
     );
-    formData.append(
-      'avatarId',
-      accountOrgProfile.value?.profile?.avatarId || ''
-    );
     const response = (await $fetch(`${storageUrl}/api/avatar`, {
       method: 'post',
       body: formData,
       credentials: 'include'
     })) as any;
-    if (response.avatarId) {
-      imageUrl.value = useUtils().generateAvatarUrl(
-        'orgMember',
-        response.avatarId,
-        '5xl'
-      ) as string;
+    if (response.avatarTimestamp) {
+      imageUrl.value = useUtils().generateAvatarUrl({
+        publicId: accountOrgProfile.value?.profile?.publicId,
+        avatarTimestamp: response.avatarTimestamp,
+        size: '5xl'
+      });
     }
     uploadLoading.value = false;
   });

--- a/apps/web-app/pages/join/profile.vue
+++ b/apps/web-app/pages/join/profile.vue
@@ -104,7 +104,7 @@
     if (response.avatarTimestamp) {
       imageUrl.value = useUtils().generateAvatarUrl({
         publicId: accountOrgProfile.value?.profile?.publicId,
-        avatarTimestamp: response.avatarTimestamp,
+        avatarTimestamp: new Date(),
         size: '5xl'
       });
     }

--- a/packages/database/schema.ts
+++ b/packages/database/schema.ts
@@ -32,12 +32,6 @@ const stripePlanNames = ['starter', 'pro'] as const;
 
 // These custom types support incompatibilities with drizzle-orm or types that must remain in sync across db
 
-const avatarId = customType<{ data: string }>({
-  dataType() {
-    return `varchar(${nanoIdLongLength})`;
-  }
-});
-
 // Foreign Key type as drizzle does not support unsigned bigint
 const foreignKey = customType<{ data: number }>({
   dataType() {
@@ -185,7 +179,7 @@ export const orgs = mysqlTable(
   {
     id: serial('id').primaryKey(),
     publicId: publicId('org', 'public_id').notNull(),
-    avatarId: avatarId('avatar_id'),
+    avatarTimestamp: timestamp('avatar_timestamp'),
     slug: varchar('slug', { length: 64 }).notNull(),
     ownerId: foreignKey('owner_id').notNull(),
     name: varchar('name', { length: 64 }).notNull(),
@@ -368,7 +362,7 @@ export const orgMemberProfiles = mysqlTable(
     id: serial('id').primaryKey(),
     publicId: publicId('orgMemberProfile', 'public_id').notNull(),
     orgId: foreignKey('org_id').notNull(),
-    avatarId: avatarId('avatar_id'),
+    avatarTimestamp: timestamp('avatar_timestamp'),
     accountId: foreignKey('account_id'),
     firstName: varchar('first_name', { length: 64 }),
     lastName: varchar('last_name', { length: 64 }),
@@ -402,7 +396,7 @@ export const groups = mysqlTable(
   {
     id: serial('id').primaryKey(),
     publicId: publicId('groups', 'public_id').notNull(),
-    avatarId: avatarId('avatar_id'),
+    avatarTimestamp: timestamp('avatar_timestamp'),
     orgId: foreignKey('org_id').notNull(),
     name: varchar('name', { length: 128 }).notNull(),
     color: mysqlEnum('color', [...uiColors]),
@@ -575,7 +569,7 @@ export const contacts = mysqlTable(
   {
     id: serial('id').primaryKey(),
     publicId: publicId('contacts', 'public_id').notNull(),
-    avatarId: avatarId('avatar_id'),
+    avatarTimestamp: timestamp('avatar_timestamp'),
     orgId: foreignKey('org_id').notNull(),
     reputationId: foreignKey('reputation_id').notNull(),
     name: varchar('name', { length: 128 }),


### PR DESCRIPTION
addresses #178

switches avatars to be stored under the profile ID
adds typesafety to the IDs
adds "avatarTimestamp" used to avoid caching issues