### PR TITLE
fix(auth): when setting up 2fa, ensure 2fa enabled on page refresh

### DIFF
--- a/apps/platform/trpc/routers/authRouter/twoFactorRouter.ts
+++ b/apps/platform/trpc/routers/authRouter/twoFactorRouter.ts
@@ -23,7 +23,8 @@ export const twoFactorRouter = router({
         with: {
           accountCredential: {
             columns: {
-              twoFactorSecret: true
+              twoFactorSecret: true,
+              twoFactorEnabled: true
             }
           }
         }
@@ -36,7 +37,7 @@ export const twoFactorRouter = router({
         });
       }
 
-      if (existingData.accountCredential.twoFactorSecret) {
+      if (existingData.accountCredential.twoFactorEnabled) {
         throw new TRPCError({
           code: 'BAD_REQUEST',
           message:


### PR DESCRIPTION
There was an issue where:
When creating account using password
if the user refreshes the screen before scanning the 2FA QR code
the system would think that 2FA is set up and not show the code again

this change checks if 2fa has been validated, if not, it creates a new code