### PR TITLE
feat(all): store raw incoming html emails and headers

### DIFF
--- a/apps/mail-bridge/routes/postal/mail/inbound/[...mailServer].post.ts
+++ b/apps/mail-bridge/routes/postal/mail/inbound/[...mailServer].post.ts
@@ -14,7 +14,8 @@ import {
   convoSubjects,
   convos,
   emailIdentities,
-  postalServers
+  postalServers,
+  convoEntryRawHtmlEmails
 } from '@u22n/database/schema';
 import { parseMessage } from '@u22n/mailtools';
 import type {
@@ -817,7 +818,13 @@ export default eventHandler(async (event) => {
     );
   }
 
-  ///! Notifications
+  await db.insert(convoEntryRawHtmlEmails).values({
+    orgId: orgId,
+    entryId: Number(insertNewConvoEntry.insertId),
+    html: parsedEmail.html || parsedEmail.textAsHtml || '',
+    headers: Object.fromEntries(parsedEmail.headers),
+    wipeDate: new Date(Date.now() + 1000 * 60 * 60 * 24 * 28) // 28 days
+  });
 
   await sendRealtimeNotification({
     newConvo: !inReplyToEmailId || hasReplyToButIsNewConvo || false,
@@ -825,6 +832,5 @@ export default eventHandler(async (event) => {
     convoEntryId: +insertNewConvoEntry.insertId
   });
 
-  // send alerts
   return;
 });

--- a/apps/platform/trpc/routers/convoRouter/entryRouter.ts
+++ b/apps/platform/trpc/routers/convoRouter/entryRouter.ts
@@ -53,7 +53,6 @@ export const convoEntryRouter = router({
         });
       }
 
-      // TODO: Add filtering for org based on input.filterOrgPublicId
       const convoDetails = await db.query.convos.findFirst({
         columns: {
           id: true
@@ -150,6 +149,12 @@ export const convoEntryRouter = router({
             columns: {
               publicId: true
             }
+          },
+          rawHtml: {
+            columns: {
+              wipeDate: true,
+              keep: true
+            }
           }
         }
       });
@@ -221,7 +226,6 @@ export const convoEntryRouter = router({
         });
       }
 
-      // TODO: Add filtering for org based on input.filterOrgPublicId
       const convoDetails = await db.query.convos.findFirst({
         columns: {
           id: true
@@ -310,6 +314,12 @@ export const convoEntryRouter = router({
             columns: {
               publicId: true
             }
+          },
+          rawHtml: {
+            columns: {
+              wipeDate: true,
+              keep: true
+            }
           }
         }
       });
@@ -342,6 +352,141 @@ export const convoEntryRouter = router({
 
       return {
         entry: convoEntryQuery
+      };
+    }),
+  getConvoSingleEntryRawEmail: orgProcedure
+    .input(
+      z.object({
+        convoEntryPublicId: typeIdValidator('convoEntries')
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      const { db, org } = ctx;
+
+      if (!ctx.account || !ctx.org) {
+        throw new TRPCError({
+          code: 'UNPROCESSABLE_CONTENT',
+          message: 'Account or Organization is not defined'
+        });
+      }
+      if (!org?.memberId) {
+        throw new TRPCError({
+          code: 'UNPROCESSABLE_CONTENT',
+          message: 'Account is not a member of the organization'
+        });
+      }
+
+      const orgId = org.id;
+      const accountOrgMemberId = org.memberId;
+
+      const { convoEntryPublicId } = input;
+
+      // get the entries
+      const convoEntryQuery = await db.query.convoEntries.findFirst({
+        where: and(
+          eq(convoEntries.orgId, orgId),
+          eq(convoEntries.publicId, convoEntryPublicId)
+        ),
+        columns: {
+          publicId: true,
+          convoId: true
+        },
+        with: {
+          rawHtml: {
+            columns: {
+              wipeDate: true,
+              keep: true,
+              headers: true,
+              html: true,
+              wiped: true
+            }
+          }
+        }
+      });
+
+      if (!convoEntryQuery) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Convo Entry not found'
+        });
+      }
+
+      // check if the conversation belongs to the same org, early return if not before multiple db selects
+      const convoResponse = await db.query.convos.findFirst({
+        where: and(
+          eq(convos.id, convoEntryQuery.convoId),
+          eq(convos.orgId, orgId)
+        ),
+        columns: {
+          id: true
+        }
+      });
+      if (!convoResponse) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Conversation not found or not in this organization'
+        });
+      }
+
+      const convoDetails = await db.query.convos.findFirst({
+        columns: {
+          id: true
+        },
+        where: eq(convos.id, convoResponse.id),
+        with: {
+          participants: {
+            columns: {
+              id: true
+            },
+            with: {
+              orgMember: {
+                columns: {
+                  id: true
+                }
+              },
+              group: {
+                columns: {
+                  id: true
+                },
+                with: {
+                  members: {
+                    columns: {
+                      orgMemberId: true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      });
+      if (!convoDetails) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Conversation not found'
+        });
+      }
+
+      //Check if the user's orgMemberId is in the conversation
+      const convoParticipantsOrgMemberIds: number[] = [];
+      convoDetails?.participants.forEach((participant) => {
+        participant.orgMember?.id &&
+          convoParticipantsOrgMemberIds.push(participant.orgMember?.id);
+        participant.group?.members.forEach((groupMember) => {
+          groupMember.orgMemberId &&
+            convoParticipantsOrgMemberIds.push(groupMember.orgMemberId);
+        });
+      });
+
+      if (!convoParticipantsOrgMemberIds.includes(accountOrgMemberId)) {
+        throw new TRPCError({
+          code: 'UNAUTHORIZED',
+          message: 'You are not a participant of this conversation'
+        });
+      }
+
+      return {
+        rawEmailData: convoEntryQuery.rawHtml
       };
     })
 });

--- a/apps/web-app/components/convos/convoMessageItem.vue
+++ b/apps/web-app/components/convos/convoMessageItem.vue
@@ -240,6 +240,7 @@
           <span class="text-base-11 text-sm uppercase"> Raw Email </span>
           <div class="relative h-0 w-full overflow-hidden pb-[60%]">
             <iframe
+              sandbox=""
               class="absolute left-0 top-0 h-full w-full border-0"
               title="HTML Email Content"
               :srcdoc="`<style>body { font-family: Arial, Helvetica, sans-serif; }</style>${rawHtmlData?.rawEmailData.html}`"></iframe>

--- a/apps/web-app/components/convos/convoMessageItem.vue
+++ b/apps/web-app/components/convos/convoMessageItem.vue
@@ -2,7 +2,7 @@
   import { useTimeAgo } from '@vueuse/core';
   import { tiptapHtml } from '@u22n/tiptap';
   import { tipTapExtensions } from '@u22n/tiptap/extensions';
-  import { computed, inject, useNuxtApp } from '#imports';
+  import { computed, inject, ref, useNuxtApp } from '#imports';
 
   const { $trpc } = useNuxtApp();
 
@@ -64,6 +64,33 @@
   function setAsReplyTo() {
     emits('set-as-reply-to');
   }
+
+  // Raw HTML Fields
+
+  const {
+    data: rawHtmlData,
+    status: rawHtmlStatus,
+    execute: rawHtmlExecute
+  } = $trpc.convos.entries.getConvoSingleEntryRawEmail.useLazyQuery(
+    {
+      convoEntryPublicId: props.entry.publicId
+    },
+    { immediate: false }
+  );
+  const entryHasRawHtml = computed(() => {
+    return props.entry.rawHtml?.wipeDate ? true : false;
+  });
+
+  const showRawHtmlModalVisible = ref(false);
+  const showRawHtmlModalHeaders = ref(false);
+
+  const openRawHtmlModal = () => {
+    rawHtmlExecute();
+    showRawHtmlModalVisible.value = true;
+  };
+  const closeRawHtmlModal = () => {
+    showRawHtmlModalVisible.value = false;
+  };
 </script>
 <template>
   <div
@@ -98,19 +125,22 @@
             >
           </div>
           <div class="flex flex-row gap-0">
+            <UnUiTooltip
+              v-if="entryHasRawHtml"
+              text="View original message">
+              <UnUiButton
+                size="xs"
+                square
+                variant="soft"
+                icon="i-ph-code"
+                @click="openRawHtmlModal" />
+            </UnUiTooltip>
             <UnUiTooltip text="Report a bug">
               <UnUiButton
                 size="xs"
                 square
                 variant="soft"
                 icon="i-ph-bug" />
-            </UnUiTooltip>
-            <UnUiTooltip text="View original message">
-              <UnUiButton
-                size="xs"
-                square
-                variant="soft"
-                icon="i-ph-code" />
             </UnUiTooltip>
             <UnUiCopy
               icon="i-ph-hash"
@@ -144,5 +174,81 @@
         </div>
       </div>
     </div>
+    <UnUiModal
+      v-model="showRawHtmlModalVisible"
+      :fullscreen="true">
+      <template #header>
+        <span class="">Original Email Message</span>
+      </template>
+      <div v-if="rawHtmlStatus === 'pending'">Loading...</div>
+      <div
+        v-else-if="rawHtmlStatus === 'error'"
+        class="overflow-scroll">
+        Error loading raw HTML
+      </div>
+      <div
+        v-else-if="rawHtmlStatus === 'success'"
+        class="divide-base-7 flex flex-col gap-8 divide-y-2 overflow-scroll">
+        <div>
+          <UnUiButton
+            v-if="rawHtmlData?.rawEmailData.headers"
+            :label="!showRawHtmlModalHeaders ? 'Show Headers' : 'Hide Headers'"
+            @click="showRawHtmlModalHeaders = !showRawHtmlModalHeaders" />
+        </div>
+        <div
+          v-if="showRawHtmlModalHeaders && rawHtmlData?.rawEmailData.headers">
+          <template
+            v-for="(value, key, index) in rawHtmlData?.rawEmailData.headers"
+            :key="index">
+            <div class="mb-2 grid-cols-6 gap-2">
+              <span class="text-base-11 col-span-1 text-xs uppercase">
+                {{ key }}:
+              </span>
+              <div class="col-span-5">
+                <span v-if="typeof value === 'object'">
+                  <template
+                    v-for="(subValue, subKey, subIndex) in value"
+                    :key="subIndex">
+                    <span class="font-mono text-xs"
+                      >{{ subKey }}: {{ subValue }}</span
+                    >
+                  </template>
+                </span>
+                <span
+                  v-else
+                  class="font-mono text-xs">
+                  {{ value }}
+                </span>
+              </div>
+            </div>
+          </template>
+          <span class="text-base-11 col-span-1 text-sm uppercase">
+            END OF HEADERS
+          </span>
+        </div>
+        <div
+          v-if="rawHtmlData?.rawEmailData.wipeDate"
+          class="flex flex-col gap-2">
+          <span class="text-base-11 text-sm uppercase">
+            Raw message will be deleted on
+          </span>
+          <span class="text-sm">{{ rawHtmlData?.rawEmailData.wipeDate }}</span>
+        </div>
+        <div
+          v-if="rawHtmlData?.rawEmailData.html"
+          class="mb-4 flex flex-col gap-2">
+          <span class="text-base-11 text-sm uppercase"> Raw Email </span>
+          <div class="relative h-0 w-full overflow-hidden pb-[60%]">
+            <iframe
+              class="absolute left-0 top-0 h-full w-full border-0"
+              title="HTML Email Content"
+              :srcdoc="`<style>body { font-family: Arial, Helvetica, sans-serif; }</style>${rawHtmlData?.rawEmailData.html}`"></iframe>
+          </div>
+        </div>
+      </div>
+      <UnUiButton
+        label="Close"
+        @click="closeRawHtmlModal()" />
+    </UnUiModal>
   </div>
 </template>

--- a/packages/database/schema.ts
+++ b/packages/database/schema.ts
@@ -18,7 +18,6 @@ import {
   customType
 } from 'drizzle-orm/mysql-core';
 import { relations } from 'drizzle-orm';
-import { nanoIdLongLength } from '@u22n/utils';
 import { uiColors } from '@u22n/types/ui';
 import { typeIdDataType as publicId } from '@u22n/utils/typeId';
 
@@ -1231,7 +1230,11 @@ export const convoEntriesRelations = relations(
       references: [convoEntryReplies.entrySourceId],
       relationName: 'inReplyTo'
     }),
-    seenBy: many(convoEntrySeenTimestamps)
+    seenBy: many(convoEntrySeenTimestamps),
+    rawHtml: one(convoEntryRawHtmlEmails, {
+      fields: [convoEntries.id],
+      references: [convoEntryRawHtmlEmails.entryId]
+    })
   })
 );
 
@@ -1289,6 +1292,34 @@ export const convoEntryPrivateVisibilityParticipantsRelations = relations(
     convoMember: one(convoParticipants, {
       fields: [convoEntryPrivateVisibilityParticipants.convoMemberId],
       references: [convoParticipants.id]
+    })
+  })
+);
+
+export const convoEntryRawHtmlEmails = mysqlTable(
+  'convo_entry_raw_html_emails',
+  {
+    id: serial('id').primaryKey(),
+    orgId: foreignKey('org_id').notNull(),
+    entryId: foreignKey('entry_id').notNull(),
+    html: text('html').notNull(),
+    createdAt: timestamp('created_at').defaultNow().notNull()
+  },
+  (table) => ({
+    entryIdIndex: index('entry_id_idx').on(table.entryId)
+  })
+);
+
+export const convoEntryRawHtmlEmailsRelations = relations(
+  convoEntryRawHtmlEmails,
+  ({ one }) => ({
+    convoEntry: one(convoEntries, {
+      fields: [convoEntryRawHtmlEmails.entryId],
+      references: [convoEntries.id]
+    }),
+    org: one(orgs, {
+      fields: [convoEntryRawHtmlEmails.orgId],
+      references: [orgs.id]
     })
   })
 );

--- a/packages/database/schema.ts
+++ b/packages/database/schema.ts
@@ -1302,8 +1302,11 @@ export const convoEntryRawHtmlEmails = mysqlTable(
     id: serial('id').primaryKey(),
     orgId: foreignKey('org_id').notNull(),
     entryId: foreignKey('entry_id').notNull(),
+    headers: json('headers').notNull(),
     html: text('html').notNull(),
-    createdAt: timestamp('created_at').defaultNow().notNull()
+    wipeDate: timestamp('wipe_date').notNull(),
+    keep: boolean('keep').notNull().default(false),
+    wiped: boolean('wiped').notNull().default(false)
   },
   (table) => ({
     entryIdIndex: index('entry_id_idx').on(table.entryId)


### PR DESCRIPTION
this PR adds functionality to store all incoming email's headers and html body

it then offers a way for users to view the raw email data in the ui

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/dHnNldJnPYiyBYdJ5U45/7453e252-06f4-461b-a88a-9822c1e18e23.png)



this opens up a modal to view the headers and orginal html body

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/dHnNldJnPYiyBYdJ5U45/3783bf41-f6ae-459c-b568-86bd00030c08.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/dHnNldJnPYiyBYdJ5U45/d1ccbb2d-1d6d-49e0-be3f-0f5a5107db8b.png)


Raw messages are given an expiry data, after which a cron job will delete the raw data to reduce DB usage