### PR TITLE
feat: add mail-bridge functions and routes for external SMTP

### DIFF
--- a/apps/mail-bridge/package.json
+++ b/apps/mail-bridge/package.json
@@ -32,8 +32,12 @@
     "mailparser": "^3.6.9",
     "mysql2": "^3.9.2",
     "nitropack": "^2.9.4",
+    "nodemailer": "^6.9.13",
     "superjson": "^2.2.1",
     "trpc-nuxt": "^0.10.20",
     "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "@types/nodemailer": "^6.4.14"
   }
 }

--- a/apps/mail-bridge/smtp/auth.ts
+++ b/apps/mail-bridge/smtp/auth.ts
@@ -1,0 +1,42 @@
+import { createTransport } from 'nodemailer';
+
+export type AuthOptions = {
+  host: string;
+  port?: number;
+  username: string;
+  password: string;
+  encryption: 'ssl' | 'tls' | 'starttls' | 'none';
+  authMethod: 'plain' | 'login';
+};
+
+export async function validateSmtpCredentials({
+  host,
+  port,
+  username,
+  password,
+  encryption,
+  authMethod
+}: AuthOptions) {
+  const transport = createTransport({
+    host,
+    port,
+    secure: encryption === 'ssl' || encryption === 'tls',
+    auth: {
+      user: username,
+      pass: password,
+      method: authMethod.toUpperCase()
+    }
+  });
+  const status = await transport
+    .verify()
+    .then(() => ({ valid: true, error: null }) as const)
+    .catch(
+      (e) =>
+        ({
+          valid: false,
+          error: e.message as string
+        }) as const
+    );
+  transport.close();
+  return status;
+}

--- a/apps/mail-bridge/smtp/sendEmail.ts
+++ b/apps/mail-bridge/smtp/sendEmail.ts
@@ -1,0 +1,69 @@
+import { createTransport } from 'nodemailer';
+import type { AuthOptions } from './auth';
+
+export type SendEmailOptions = {
+  to: string[];
+  cc: string[];
+  from: string;
+  sender: string;
+  subject: string;
+  plainBody: string;
+  htmlBody: string;
+  attachments: {
+    name: string;
+    content_type: string;
+    data: string;
+    base64: boolean;
+  }[];
+  headers: Record<string, string>;
+};
+
+export async function sendEmail({
+  auth: { host, port, username, password, encryption, authMethod },
+  email: {
+    to,
+    cc,
+    from,
+    sender,
+    subject,
+    plainBody,
+    htmlBody,
+    attachments,
+    headers
+  }
+}: {
+  auth: AuthOptions;
+  email: SendEmailOptions;
+}) {
+  const transport = createTransport({
+    host,
+    port,
+    secure: encryption === 'ssl' || encryption === 'tls',
+    auth: {
+      user: username,
+      pass: password,
+      method: authMethod.toUpperCase()
+    }
+  });
+  const res = await transport.sendMail({
+    envelope: {
+      to,
+      from
+    },
+    to,
+    cc,
+    from,
+    sender,
+    subject,
+    html: htmlBody,
+    text: plainBody,
+    attachments: attachments.map(({ name, content_type, data, base64 }) => ({
+      contentType: content_type,
+      filename: name,
+      content: data,
+      encoding: base64 ? 'base64' : 'utf8'
+    })),
+    headers
+  });
+  return res;
+}

--- a/apps/mail-bridge/trpc/index.ts
+++ b/apps/mail-bridge/trpc/index.ts
@@ -4,6 +4,7 @@ import { createContext } from './createContext';
 import { orgRouter } from './routers/orgRouter';
 import { domainRouter } from './routers/domainRouter';
 import { sendMailRouter } from './routers/sendMailRouter';
+import { smtpRouter } from './routers/smtpRouter';
 
 export const trpcMailBridgeContext = createContext;
 export const trpcMailBridgePostalRouter = router({
@@ -15,7 +16,8 @@ export const trpcMailBridgeMailRouter = router({
 });
 export const trpcMailBridgeRouter = router({
   mail: trpcMailBridgeMailRouter,
-  postal: trpcMailBridgePostalRouter
+  postal: trpcMailBridgePostalRouter,
+  smtp: smtpRouter
 });
 
 export type TrpcMailBridgeRouter = typeof trpcMailBridgeRouter;

--- a/apps/mail-bridge/trpc/routers/sendMailRouter.ts
+++ b/apps/mail-bridge/trpc/routers/sendMailRouter.ts
@@ -21,6 +21,7 @@ import type { PostalConfig } from '../../types';
 import { useRuntimeConfig } from '#imports';
 import { tiptapHtml, tiptapVue3 } from '@u22n/tiptap';
 import { tipTapExtensions } from '@u22n/tiptap/extensions';
+import { sendEmail } from '../../smtp/sendEmail';
 
 export const sendMailRouter = router({
   sendConvoEntryEmail: protectedProcedure
@@ -194,7 +195,20 @@ export const sendMailRouter = router({
           username: true,
           domainName: true,
           sendName: true,
-          personalEmailIdentityId: true
+          personalEmailIdentityId: true,
+          externalCredentialsId: true
+        },
+        with: {
+          externalCredentials: {
+            columns: {
+              host: true,
+              port: true,
+              username: true,
+              password: true,
+              encryption: true,
+              authMethod: true
+            }
+          }
         }
       });
 
@@ -585,6 +599,43 @@ export const sendMailRouter = router({
           }
         : {};
 
+      // If there is external email credentials then the identity is external, use their smtp server instead of postal's
+      if (sendAsEmailIdentity.externalCredentialsId) {
+        const auth = sendAsEmailIdentity.externalCredentials!; // it should be defined here
+        return await sendEmail({
+          auth,
+          email: {
+            to: [`${convoToAddress}`],
+            cc: convoCcAddressesFiltered,
+            from: convoFromStringObject,
+            sender: convoSenderEmailAddress,
+            subject: convoEntryResponse.subject?.subject || 'No Subject',
+            plainBody: emailBodyPlainText,
+            htmlBody: emailBodyHTML,
+            attachments: postalAttachments,
+            headers: emailHeaders
+          }
+        })
+          .then(
+            (data) =>
+              ({
+                email: {
+                  to: [convoMetadataToAddress!],
+                  from: [convoMetadataFromAddress],
+                  cc: convoMetadataCcAddresses,
+                  messageId: data.messageId,
+                  postalMessages: [] // Not sure about this one
+                }
+              }) satisfies ConvoEntryMetadata
+          )
+          .catch((e) => {
+            console.error('🚨 error sending email as external identity', e);
+            return {
+              success: false
+            };
+          });
+      }
+
       type PostalResponse =
         | {
             status: 'success';
@@ -661,286 +712,6 @@ export const sendMailRouter = router({
           })
           .where(eq(convoEntries.id, entryId));
 
-        return {
-          success: true,
-          metadata: entryMetadata as ConvoEntryMetadata
-        };
-      } else {
-        console.error(
-          `🚨 attempted to send convoId: ${entryId} from convoId: ${convoId}, but got the following error`,
-          sendMailPostalResponse.data.message
-        );
-        return {
-          success: false
-        };
-      }
-    }),
-  sendNewEmail: protectedProcedure
-    // to, cc, subject, bodyPlain, bodyHTML, attachmentIds, sendAsEmailIdentityPublicId
-    .input(
-      z.object({
-        orgId: z.number(),
-        convoId: z.number(),
-        entryId: z.number(),
-        sendAsEmailIdentityPublicId: typeIdValidator('emailIdentities'),
-        toEmail: z.string().email(),
-        ccEmail: z.array(z.string().email()).optional(),
-        subject: z.string(),
-        bodyPlainText: z.string(),
-        bodyHtml: z.string(),
-        attachments: z.array(
-          z.object({
-            orgPublicId: typeIdValidator('org'),
-            attachmentPublicId: typeIdValidator('convoAttachments'),
-            fileName: z.string(),
-            fileType: z.string()
-          })
-        )
-      })
-    )
-    .mutation(async ({ ctx, input }) => {
-      const { config, db } = ctx;
-      const postalConfig = config.postal as PostalConfig;
-
-      if (postalConfig.localMode === true) {
-        return {
-          success: true,
-          metadata: {
-            email: {
-              to: [{ id: 0, type: 'emailIdentity' }],
-              from: [{ id: 1, type: 'emailIdentity' }],
-              cc: [],
-              messageId: 'localModeMessageId',
-              postalMessages: [
-                {
-                  recipient: 'localModeRecipient',
-                  id: 1,
-                  token: 'localModeToken',
-                  postalMessageId: 'localModeMessageId'
-                }
-              ]
-            }
-          }
-        };
-      }
-
-      const {
-        orgId,
-        convoId,
-        entryId,
-        sendAsEmailIdentityPublicId,
-        toEmail,
-        ccEmail,
-        subject,
-        bodyPlainText,
-        bodyHtml,
-        attachments
-      } = input;
-
-      const sendAsEmailIdentity = await db.query.emailIdentities.findFirst({
-        where: eq(emailIdentities.publicId, sendAsEmailIdentityPublicId),
-        columns: {
-          id: true,
-          publicId: true,
-          username: true,
-          domainName: true,
-          sendName: true,
-          personalEmailIdentityId: true
-        }
-      });
-
-      if (!sendAsEmailIdentity) {
-        console.error('🚨 sendAsEmailIdentity not found');
-        return {
-          success: false
-        };
-      }
-
-      const sendEmailAddress = `${sendAsEmailIdentity.username}@${sendAsEmailIdentity.domainName}`;
-      const sendName = `${sendAsEmailIdentity.sendName} <${sendEmailAddress}>`;
-      let postalServerUrl: string;
-      let postalServerAPIKey: string;
-
-      if (sendAsEmailIdentity.personalEmailIdentityId) {
-        postalServerUrl = `https://${postalConfig.personalServerCredentials.apiUrl}/api/v1/send/message`;
-        postalServerAPIKey = postalConfig.personalServerCredentials.apiKey;
-      } else {
-        const orgPostalServerResponse = await db.query.postalServers.findFirst({
-          where: and(
-            eq(postalServers.orgId, orgId),
-            eq(postalServers.type, 'email')
-          ),
-          columns: {
-            apiKey: true
-          },
-          with: {
-            orgPostalConfigs: {
-              columns: {
-                host: true
-              }
-            }
-          }
-        });
-        if (!orgPostalServerResponse) {
-          console.error('🚨 orgPostalServerResponse not found');
-          return {
-            success: false
-          };
-        }
-        postalServerAPIKey = orgPostalServerResponse.apiKey;
-        const postalServerConfigItem = postalConfig.servers.find(
-          (server) =>
-            server.url === orgPostalServerResponse.orgPostalConfigs.host
-        );
-        postalServerUrl = `https://${postalServerConfigItem?.controlPanelSubDomain}.${postalServerConfigItem?.url}/api/v1/send/message`;
-      }
-
-      //* Attachments
-      // expected postal type: { name: attachment["name"], content_type: attachment["content_type"], data: attachment["data"], base64: true }
-      type PostalAttachmentType = {
-        name: string;
-        content_type: string;
-        data: string;
-        base64: boolean;
-      };
-      const postalAttachments: PostalAttachmentType[] = [];
-
-      async function getAttachment(input: {
-        orgPublicId: string;
-        attachmentPublicId: string;
-        fileName: string;
-      }) {
-        type GetUrlResponse = {
-          url: string;
-        };
-        const downloadUrl = (await fetch(
-          `${useRuntimeConfig().storage.url}/api/attachments/mailfetch`,
-          {
-            method: 'post',
-
-            headers: {
-              'Content-Type': 'application/json',
-              Authorization: useRuntimeConfig().storage.key
-            },
-            body: JSON.stringify({
-              orgPublicId: input.orgPublicId,
-              attachmentPublicId: input.attachmentPublicId,
-              filename: input.fileName
-            })
-          }
-        ).then((res) => res.json())) as GetUrlResponse;
-        if (!downloadUrl || !downloadUrl.url) {
-          throw new Error('something went wrong getting the attachment URL');
-        }
-
-        try {
-          const response = await fetch(downloadUrl.url);
-          const buffer = await response.arrayBuffer();
-          const base64 = Buffer.from(buffer).toString('base64');
-          return base64;
-        } catch (error) {
-          console.error('Error downloading the presigned url file:', error);
-          throw error; // Rethrow to handle it in the outer catch block
-        }
-      }
-      if (attachments && attachments.length > 0) {
-        for (const attachment of attachments) {
-          try {
-            const base64 = await getAttachment({
-              orgPublicId: attachment.orgPublicId,
-              attachmentPublicId: attachment.attachmentPublicId,
-              fileName: attachment.fileName
-            });
-            postalAttachments.push({
-              name: attachment.fileName,
-              content_type: attachment.fileType,
-              data: base64,
-              base64: true
-            });
-          } catch (error) {
-            console.error('Error getting attachment:', error);
-          }
-        }
-      }
-
-      //* Send email
-
-      type PostalResponse =
-        | {
-            status: 'success';
-            time: number;
-            flags: any;
-            data: {
-              message_id: string;
-              messages: {
-                [email: string]: {
-                  id: number;
-                  token: string;
-                };
-              };
-            };
-          }
-        | {
-            status: 'parameter-error';
-            time: number;
-            flags: any;
-            data: {
-              message: string;
-            };
-          };
-      const sendMailPostalResponse = (await fetch(postalServerUrl, {
-        method: 'POST',
-        headers: {
-          'X-Server-API-Key': `${postalServerAPIKey}`,
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-          to: [`${toEmail}`],
-          cc: ccEmail,
-          from: sendName,
-          sender: sendEmailAddress,
-          subject: subject,
-          plain_body: bodyPlainText,
-          html_body: bodyHtml,
-          attachments: postalAttachments
-        })
-      })
-        .then((res) => res.json())
-        .catch((e) => {
-          console.error('🚨 error sending email', e);
-        })) as PostalResponse;
-
-      if (sendMailPostalResponse.status === 'success') {
-        const transformedMessages = Object.entries(
-          sendMailPostalResponse.data.messages
-        ).map(([recipient, { id, token }]) => ({
-          recipient,
-          id,
-          token
-        }));
-
-        const entryMetadata: ConvoEntryMetadata = {
-          email: {
-            to: [],
-            from: [
-              {
-                id: +sendAsEmailIdentity.id,
-                type: 'emailIdentity',
-                publicId: sendAsEmailIdentity.publicId,
-                email:
-                  sendAsEmailIdentity.username +
-                  '@' +
-                  sendAsEmailIdentity.domainName
-              }
-            ],
-            cc: [],
-            messageId: sendMailPostalResponse.data.message_id,
-            postalMessages: transformedMessages.map((message) => ({
-              ...message,
-              postalMessageId: sendMailPostalResponse.data.message_id
-            }))
-          }
-        };
         return {
           success: true,
           metadata: entryMetadata as ConvoEntryMetadata

--- a/apps/mail-bridge/trpc/routers/smtpRouter.ts
+++ b/apps/mail-bridge/trpc/routers/smtpRouter.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+import { validateSmtpCredentials } from '../../smtp/auth';
+import { protectedProcedure, router } from '../trpc';
+
+export const smtpRouter = router({
+  validateSmtpCredentials: protectedProcedure
+    .input(
+      z.object({
+        host: z.string(),
+        port: z.number(),
+        username: z.string(),
+        password: z.string(),
+        encryption: z.enum(['none', 'ssl', 'tls', 'starttls']),
+        authMethod: z.enum(['plain', 'login'])
+      })
+    )
+    .mutation(({ input }) => validateSmtpCredentials(input))
+});

--- a/packages/database/schema.ts
+++ b/packages/database/schema.ts
@@ -871,8 +871,10 @@ export const emailIdentityExternal = mysqlTable(
     }).notNull(),
     host: varchar('hostname', { length: 128 }).notNull(),
     port: smallint('port').notNull(),
-    authMethod: mysqlEnum('auth_method', ['plain', 'login', 'cram_md5']),
-    encryption: mysqlEnum('encryption', ['ssl', 'tls', 'starttls', 'none']),
+    authMethod: mysqlEnum('auth_method', ['plain', 'login']).notNull(), // No support for CRAM_MD5 yet, does it even gets used?
+    encryption: mysqlEnum('encryption', ['ssl', 'tls', 'starttls', 'none'])
+      .default('none')
+      .notNull(),
     createdAt: timestamp('created_at').defaultNow().notNull()
   },
   (table) => ({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 importers:
 
   .:
@@ -94,6 +98,9 @@ importers:
       nitropack:
         specifier: ^2.9.4
         version: 2.9.4(drizzle-orm@0.30.3)
+      nodemailer:
+        specifier: ^6.9.13
+        version: 6.9.13
       superjson:
         specifier: ^2.2.1
         version: 2.2.1
@@ -103,6 +110,10 @@ importers:
       zod:
         specifier: ^3.22.4
         version: 3.22.4
+    devDependencies:
+      '@types/nodemailer':
+        specifier: ^6.4.14
+        version: 6.4.14
 
   apps/platform:
     dependencies:
@@ -5219,6 +5230,12 @@ packages:
     dependencies:
       undici-types: 5.26.5
 
+  /@types/nodemailer@6.4.14:
+    resolution: {integrity: sha512-fUWthHO9k9DSdPCSPRqcu6TWhYyxTBg382vlNIttSe9M7XfsT06y0f24KHXtbnijPGGRIcVvdKHTNikOI6qiHA==}
+    dependencies:
+      '@types/node': 20.12.2
+    dev: true
+
   /@types/resolve@1.20.2:
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
 
@@ -9359,6 +9376,11 @@ packages:
     engines: {node: '>=6.0.0'}
     dev: false
 
+  /nodemailer@6.9.13:
+    resolution: {integrity: sha512-7o38Yogx6krdoBf3jCAqnIN4oSQFx+fMa0I7dK1D+me9kBxx12D+/33wSb+fhOCtIxvYJ+4x4IMEhmhCKfAiOA==}
+    engines: {node: '>=6.0.0'}
+    dev: false
+
   /nodemailer@6.9.9:
     resolution: {integrity: sha512-dexTll8zqQoVJEZPwQAKzxxtFn0qTnjdQTchoU6Re9BUUGBJiOy3YMn/0ShTW6J5M0dfQ1NeDeRTTl4oIWgQMA==}
     engines: {node: '>=6.0.0'}
@@ -12732,7 +12754,3 @@ packages:
 
   /zod@3.22.4:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
## What does this PR do?

Fixes #196
Adds support for using external SMTP servers as email identities.

Todo:
- [x] UI for adding SMTP creds
- [x] Matching platfrom routes to save them into db and validate on mail-bridge

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Tested my code in a local environment
- [ ] Commented on my code in hard-to-understand areas
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the UnInbox Docs if changes were necessary
