### PR TITLE
feat: move everything to accounts table instead of credentials

### DIFF
--- a/apps/platform/trpc/routers/authRouter/passkeyRouter.ts
+++ b/apps/platform/trpc/routers/authRouter/passkeyRouter.ts
@@ -203,7 +203,7 @@ export const passkeyRouter = router({
       }
 
       const account = await db.query.accounts.findFirst({
-        where: eq(accounts.id, passkeyVerification.accountCredentialId),
+        where: eq(accounts.id, passkeyVerification.accountId),
         columns: {
           id: true,
           publicId: true,

--- a/apps/platform/trpc/routers/authRouter/passkeyRouter.ts
+++ b/apps/platform/trpc/routers/authRouter/passkeyRouter.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { router, publicRateLimitedProcedure } from '../../trpc';
 import { eq } from '@u22n/database/orm';
-import { accountCredentials, accounts } from '@u22n/database/schema';
+import { accounts } from '@u22n/database/schema';
 import { TRPCError } from '@trpc/server';
 import type {
   RegistrationResponseJSON,
@@ -29,8 +29,17 @@ export const passkeyRouter = router({
         authenticatorType: z.enum(['platform', 'cross-platform'])
       })
     )
-    .query(async ({ input }) => {
+    .query(async ({ input, ctx }) => {
+      const { db } = ctx;
       const { username, authenticatorType } = input;
+      const { available, error } = await validateUsername(db, input.username);
+      if (!available) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: error || "Username isn't available"
+        });
+      }
+
       const publicId = typeIdGenerator('account');
       const passkeyOptions = await usePasskeys.generateRegistrationOptions({
         userDisplayName: username,
@@ -53,10 +62,12 @@ export const passkeyRouter = router({
       const { db } = ctx;
       const registrationResponse =
         input.registrationResponseRaw as RegistrationResponseJSON;
+
       const passkeyVerification = await usePasskeys.verifyRegistrationResponse({
         registrationResponse: registrationResponse,
         publicId: input.publicId
       });
+
       if (
         !passkeyVerification.verified ||
         !passkeyVerification.registrationInfo
@@ -67,23 +78,23 @@ export const passkeyRouter = router({
         });
       }
 
-      // making sure someone doesn't bypass the client side validation
-      const { available, error } = await validateUsername(db, input.username);
-      if (!available) {
-        throw new TRPCError({
-          code: 'FORBIDDEN',
-          message: error || "Username isn't available"
-        });
-      }
+      const accountId = await db.transaction(async (tx) => {
+        try {
+          // making sure someone doesn't bypass the client side validation
+          const { available, error } = await validateUsername(
+            tx,
+            input.username
+          );
+          if (!available) {
+            throw new TRPCError({
+              code: 'FORBIDDEN',
+              message: error || "Username isn't available"
+            });
+          }
 
-      const accountId = await db
-        .transaction(async (tx) => {
           const newAccount = await tx.insert(accounts).values({
             username: input.username,
             publicId: input.publicId
-          });
-          await tx.insert(accountCredentials).values({
-            accountId: Number(newAccount.insertId)
           });
 
           if (!passkeyVerification.registrationInfo) {
@@ -95,7 +106,7 @@ export const passkeyRouter = router({
 
           const insertPasskey = await usePasskeysDb.createAuthenticator(
             {
-              accountCredentialId: Number(newAccount.insertId),
+              accountId: Number(newAccount.insertId),
               credentialID: passkeyVerification.registrationInfo.credentialID,
               credentialPublicKey:
                 passkeyVerification.registrationInfo.credentialPublicKey,
@@ -111,23 +122,20 @@ export const passkeyRouter = router({
           );
 
           if (!insertPasskey.credentialID) {
-            tx.rollback();
             throw new TRPCError({
               code: 'INTERNAL_SERVER_ERROR',
               message:
                 'Something went wrong adding your passkey, please try again'
             });
           }
+
           return Number(newAccount.insertId);
-        })
-        .catch((err) => {
+        } catch (err) {
+          tx.rollback();
           console.error(err);
-          throw new TRPCError({
-            code: 'INTERNAL_SERVER_ERROR',
-            message:
-              'Something went wrong adding your passkey, please try again'
-          });
-        });
+          throw err;
+        }
+      });
 
       const cookie = await createLuciaSessionCookie(ctx.event, {
         accountId,
@@ -177,6 +185,7 @@ export const passkeyRouter = router({
           message: 'Challenge not found, try again'
         });
       }
+
       const passkeyVerification =
         await usePasskeys.verifyAuthenticationResponse({
           authenticationResponse: verificationResponse,
@@ -193,32 +202,21 @@ export const passkeyRouter = router({
         });
       }
 
-      const accountCredentialQuery =
-        await db.query.accountCredentials.findFirst({
-          where: eq(
-            accountCredentials.id,
-            passkeyVerification.accountCredentialId
-          ),
-          columns: {
-            id: true
-          },
-          with: {
-            account: {
-              columns: {
-                id: true,
-                publicId: true,
-                username: true
-              }
-            }
-          }
-        });
-      if (!accountCredentialQuery) {
+      const account = await db.query.accounts.findFirst({
+        where: eq(accounts.id, passkeyVerification.accountCredentialId),
+        columns: {
+          id: true,
+          publicId: true,
+          username: true
+        }
+      });
+
+      if (!account) {
         throw new TRPCError({
           code: 'BAD_REQUEST',
-          message: 'Account account not found'
+          message: 'Account not found, please contact support'
         });
       }
-      const account = accountCredentialQuery.account;
 
       const { device, os } = UAParser(getHeader(ctx.event, 'User-Agent'));
       const userDevice =

--- a/apps/platform/trpc/routers/userRouter/defaultsRouter.ts
+++ b/apps/platform/trpc/routers/userRouter/defaultsRouter.ts
@@ -13,6 +13,11 @@ export const defaultsRouter = router({
 
       const accountResponse = await db.query.accounts.findFirst({
         where: eq(accounts.id, accountId),
+        columns: {
+          twoFactorSecret: true,
+          passwordHash: true,
+          twoFactorEnabled: true
+        },
         with: {
           orgMemberships: {
             with: {
@@ -23,18 +28,9 @@ export const defaultsRouter = router({
               }
             }
           },
-          accountCredential: {
+          authenticators: {
             columns: {
-              twoFactorSecret: true,
-              passwordHash: true,
-              twoFactorEnabled: true
-            },
-            with: {
-              authenticators: {
-                columns: {
-                  id: true
-                }
-              }
+              id: true
             }
           }
         }
@@ -44,12 +40,10 @@ export const defaultsRouter = router({
         throw new Error('User not found');
       }
 
-      const userHasPasskeys =
-        accountResponse.accountCredential.authenticators.length > 0;
+      const userHasPasskeys = accountResponse.authenticators.length > 0;
 
       const twoFactorEnabledCorrectly =
-        accountResponse.accountCredential.passwordHash &&
-        accountResponse.accountCredential.twoFactorEnabled;
+        accountResponse.passwordHash && accountResponse.twoFactorEnabled;
 
       return {
         defaultOrgShortcode:

--- a/apps/platform/utils/auth/luciaDbAdaptor.ts
+++ b/apps/platform/utils/auth/luciaDbAdaptor.ts
@@ -202,20 +202,14 @@ export class UnInboxDBAdapter implements Adapter {
           columns: {
             id: true,
             username: true,
-            publicId: true
+            publicId: true,
+            twoFactorSecret: true,
+            passwordHash: true
           },
           with: {
-            accountCredential: {
+            authenticators: {
               columns: {
-                twoFactorSecret: true,
-                passwordHash: true
-              },
-              with: {
-                authenticators: {
-                  columns: {
-                    nickname: true
-                  }
-                }
+                nickname: true
               }
             }
           }
@@ -231,11 +225,9 @@ export class UnInboxDBAdapter implements Adapter {
         id: accountSessions.account.id,
         publicId: accountSessions.account.publicId,
         username: accountSessions.account.username,
-        passkeyEnabled:
-          accountSessions.account.accountCredential.authenticators.length > 0,
-        passwordEnabled:
-          !!accountSessions.account.accountCredential.passwordHash,
-        totpEnabled: !!accountSessions.account.accountCredential.twoFactorSecret
+        passkeyEnabled: accountSessions.account.authenticators.length > 0,
+        passwordEnabled: !!accountSessions.account.passwordHash,
+        totpEnabled: !!accountSessions.account.twoFactorSecret
       }
     };
     return result;

--- a/apps/platform/utils/auth/passkeys.ts
+++ b/apps/platform/utils/auth/passkeys.ts
@@ -173,7 +173,7 @@ async function verifyAuthenticationResponse({
   });
   return {
     result: verificationResult,
-    accountCredentialId: authenticator.accountId
+    accountId: authenticator.accountId
   };
 }
 

--- a/apps/platform/utils/auth/passkeys.ts
+++ b/apps/platform/utils/auth/passkeys.ts
@@ -173,7 +173,7 @@ async function verifyAuthenticationResponse({
   });
   return {
     result: verificationResult,
-    accountCredentialId: authenticator.accountCredentialId
+    accountCredentialId: authenticator.accountId
   };
 }
 

--- a/packages/database/schema.ts
+++ b/packages/database/schema.ts
@@ -110,7 +110,7 @@ export const authenticators = mysqlTable(
     id: serial('id').primaryKey(),
     publicId: publicId('accountPasskey', 'public_id').notNull(),
     accountCredentialId: foreignKey('account_credential_id').notNull(),
-    accountId: foreignKey('account_id'),
+    accountId: foreignKey('account_id').notNull(),
     nickname: varchar('nickname', { length: 64 }).notNull(),
     credentialID: varchar('credential_id', { length: 255 }).notNull(), //Uint8Array
     credentialPublicKey: varchar('credential_public_key', {


### PR DESCRIPTION
## What does this PR do?

move all auth stuff from `accountCredentials` to `accounts1 with out breaking anything

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Tested my code in a local environment
- [ ] Commented on my code in hard-to-understand areas
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the UnInbox Docs if changes were necessary
