### PR TITLE
chore: add back postal signature verification failure logs

### DIFF
--- a/apps/mail-bridge/middleware/verifyPostalSig.ts
+++ b/apps/mail-bridge/middleware/verifyPostalSig.ts
@@ -6,7 +6,8 @@ import {
   readBody,
   getHeader,
   useRuntimeConfig,
-  sendNoContent
+  sendNoContent,
+  getHeaders
 } from '#imports';
 
 export default defineEventHandler(async (event) => {
@@ -28,6 +29,13 @@ export default defineEventHandler(async (event) => {
 
     event.context.fromPostal = validPostalSignature;
     if (!validPostalSignature) {
+      const allHeaders = getHeaders(event);
+      console.error('🔥 Failed postal webhook call with these headers', {
+        allHeaders
+      });
+      console.error('🔥postal verify webhook', { publicKeys });
+      console.error('🔥 signature', { signature });
+      console.error('🔥', { validPostalSignature });
       return sendNoContent(event, 401);
     }
   }

--- a/apps/storage/routes/attachment/[orgShortcode]/[attachmentId]/[filename].ts
+++ b/apps/storage/routes/attachment/[orgShortcode]/[attachmentId]/[filename].ts
@@ -11,8 +11,7 @@ import {
   setResponseStatus,
   send,
   sendProxy,
-  useRuntimeConfig,
-  getRouterParams
+  useRuntimeConfig
 } from '#imports';
 import { validateTypeId } from '@u22n/utils';
 

--- a/apps/web-app/layouts/home.vue
+++ b/apps/web-app/layouts/home.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
   // put in the handlers for the realtime client
-  import { useRoute, useNuxtApp, ref, navigateTo, watch } from '#imports';
+  import { useRoute, useNuxtApp, ref, navigateTo } from '#imports';
   import { useRealtime } from '~/composables/realtime';
   import { useConvoEntryStore } from '~/stores/convoEntryStore';
   import { useConvoStore } from '~/stores/convoStore';

--- a/apps/web-app/layouts/home.vue
+++ b/apps/web-app/layouts/home.vue
@@ -28,6 +28,7 @@
   ) {
     showClaimEmailIdentityModal.value = true;
   }
+
   const realtime = useRealtime();
 
   realtime.connect({ orgShortcode: orgShortcode as string });

--- a/apps/web-app/pages/[orgShortcode]/convo/[id].vue
+++ b/apps/web-app/pages/[orgShortcode]/convo/[id].vue
@@ -315,19 +315,6 @@
     messageEditorData.value = emptyTiptapEditorContent;
   }
 
-  async function openAttachment(
-    attachmentPublicId: TypeId<'convoAttachments'>,
-    filename: string
-  ) {
-    const attachmentUrl = `${useRuntimeConfig().public.storageUrl}/attachment/${orgShortcode}/${attachmentPublicId}/${filename}`;
-    return navigateTo(attachmentUrl, {
-      external: true,
-      open: {
-        target: '_blank'
-      }
-    });
-  }
-
   const isContextOpen = ref(false);
 
   watch(


### PR DESCRIPTION
## What does this PR do?

Add error logs for postal signature middleware back
but dont allow to get past of it fails

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Tested my code in a local environment
- [ ] Commented on my code in hard-to-understand areas
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the UnInbox Docs if changes were necessary
