### PR TITLE
fix(web): handle body empty state

### DIFF
--- a/apps/web-app/components/convos/convoMessageItem.vue
+++ b/apps/web-app/components/convos/convoMessageItem.vue
@@ -27,10 +27,16 @@
   const timeAgo = useTimeAgo(props.entry.createdAt || new Date());
 
   const convoEntryBody = computed(() => {
+    const emptyBody =
+      '<span class="text-base-11 text-sm">THIS MESSAGE CONTAINS NO VALID TEXT CONTENT</span>';
     if (props.entry.body) {
-      return tiptapHtml.generateHTML(props.entry.body, tipTapExtensions);
+      const htmlBody = tiptapHtml.generateHTML(
+        props.entry.body,
+        tipTapExtensions
+      );
+      return htmlBody !== '<p></p>' ? htmlBody : emptyBody;
     }
-    return '';
+    return emptyBody;
   });
 
   const author = computed(() => {


### PR DESCRIPTION
handles when an email contains no text

fixes #266

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/dHnNldJnPYiyBYdJ5U45/b5b78b0c-2cbf-4a84-96d8-34bd8cc80b19.png)


