### PR TITLE
fix: use node instead of tsx directly

### DIFF
--- a/apps/mail-bridge/package.json
+++ b/apps/mail-bridge/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "dev": "tsx watch --clear-screen=false app.ts",
-    "start": "tsx app.ts",
+    "start": "node --import=tsx app.ts",
     "check": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/storage/package.json
+++ b/apps/storage/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "tsx watch --clear-screen=false src/app.ts",
-    "start": "tsx src/app.ts",
+    "start": "node --import=tsx src/app.ts",
     "check": "tsc --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
## What does this PR do?

Uses `node` in start script instead of `tsx` directly

<!-- If there isn't an issue for this PR, please re-review our Contributing Guide and create an issue -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Tested my code in a local environment
- [ ] Commented on my code in hard-to-understand areas
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the UnInbox Docs if changes were necessary
