### PR TITLE
fix: properly handle end of convos cursor, invalidate cache on logout

### DIFF
--- a/apps/platform/trpc/routers/convoRouter/convoRouter.ts
+++ b/apps/platform/trpc/routers/convoRouter/convoRouter.ts
@@ -1303,6 +1303,7 @@ export const convoRouter = router({
       const orgId = org.id;
 
       const orgMemberId = org.memberId;
+      const LIMIT = 15;
 
       const inputLastUpdatedAt = cursor.lastUpdatedAt
         ? new Date(cursor.lastUpdatedAt)
@@ -1312,7 +1313,7 @@ export const convoRouter = router({
 
       const convoQuery = await db.query.convos.findMany({
         orderBy: [desc(convos.lastUpdatedAt), desc(convos.publicId)],
-        limit: 15,
+        limit: LIMIT + 1,
         columns: {
           publicId: true,
           lastUpdatedAt: true
@@ -1455,12 +1456,16 @@ export const convoRouter = router({
         }
       });
 
-      if (!convoQuery.length) {
+      // As we fetch ${LIMIT + 1} convos at a time, if the length is <= ${LIMIT}, we know we've reached the end
+      if (convoQuery.length <= LIMIT) {
         return {
-          data: <typeof convoQuery>[],
+          data: convoQuery,
           cursor: null
         };
       }
+
+      // If we have ${LIMIT + 1} convos, we pop the last one as we return ${LIMIT} convos
+      convoQuery.pop();
 
       const newCursorLastUpdatedAt =
         convoQuery[convoQuery.length - 1]!.lastUpdatedAt;

--- a/apps/web/app/[orgShortCode]/convo/ConvoList.tsx
+++ b/apps/web/app/[orgShortCode]/convo/ConvoList.tsx
@@ -1,22 +1,33 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
 'use client';
 
-// import { api } from '@/lib/trpc';
-import { Flex, ScrollArea } from '@radix-ui/themes';
+import { api } from '@/lib/trpc';
+import { Flex } from '@radix-ui/themes';
 
 export default function ConvoList() {
-  // const {} = api.convos.getOrgMemberConvos.useInfiniteQuery({});
+  const {
+    data: convos,
+    fetchNextPage,
+    isLoading,
+    hasNextPage,
+    isFetchingNextPage
+  } = api.convos.getOrgMemberConvos.useInfiniteQuery(
+    {
+      includeHidden: false
+    },
+    {
+      initialCursor: {},
+      getNextPageParam: (lastPage) => lastPage.cursor ?? undefined
+    }
+  );
 
   return (
     <Flex className="bg-slate-2 dark:bg-slatedark-2 h-full w-[350px] p-2">
-      <ScrollArea>
-        {/* {convos.map((convo) => (
-          <Flex
-            key={convo.publicId}
-            className="p-2">
-            {JSON.stringify(convo)}
-          </Flex>
-        ))} */}
-      </ScrollArea>
+      {isLoading ? (
+        <div>Loading...</div>
+      ) : // Render the list of convos
+      null}
     </Flex>
   );
 }

--- a/apps/web/hooks/use-loading.ts
+++ b/apps/web/hooks/use-loading.ts
@@ -5,22 +5,14 @@ type Callbacks<T> = {
   onError?: (e: Error) => void;
   onSettled?: () => void;
 };
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
 
 // A simple useQuery like hook that handles loading and error states,
 // useful for doing dependent async functions like passkey login
 export default function useLoading<T>(
   fn: (signal: AbortSignal) => Promise<T>,
-  {
-    onSuccess = () => {
-      /** */
-    },
-    onError = () => {
-      /** */
-    },
-    onSettled = () => {
-      /** */
-    }
-  }: Callbacks<T> = {}
+  { onSuccess = noop, onError = noop, onSettled = noop }: Callbacks<T> = {}
 ) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);


### PR DESCRIPTION
## What does this PR do?

1. The convo cursor now properly denotes the end of convos.

2. log out invalidates cache
fixes #421

<!-- If there isn't an issue for this PR, please re-review our Contributing Guide and create an issue -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Tested my code in a local environment
- [ ] Commented on my code in hard-to-understand areas
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the UnInbox Docs if changes were necessary
