### PR TITLE
feat: add turnstile to sign in, sign up, and recovery pages

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -94,6 +94,10 @@ PRIMARY_DOMAIN='localhost'
 
 UNKEY_ROOT_KEY=""
 
+########################### TURNSTILE VARIABLES ################################
+TURNSTILE_SITE_KEY=
+TURNSTILE_SECRET_KEY=
+
 ############################ NEXT_PUBLIC VARIABLES ############################
 NEXT_PUBLIC_WEBAPP_URL=http://localhost:3000
 NEXT_PUBLIC_STORAGE_URL=http://localhost:3200
@@ -101,6 +105,7 @@ NEXT_PUBLIC_PLATFORM_URL=http://localhost:3300
 NEXT_PUBLIC_REALTIME_APP_KEY=secretsecretsecret
 NEXT_PUBLIC_REALTIME_HOST=localhost
 NEXT_PUBLIC_REALTIME_PORT=3904
+NEXT_PUBLIC_TUNSTILE_SITE_KEY=
 
 ########################## WORKER APP VARIABLES ################################
 WORKER_URL=http://localhost:3400

--- a/apps/platform/env.ts
+++ b/apps/platform/env.ts
@@ -42,6 +42,7 @@ export const env = createEnv({
     STORAGE_URL: z.string().url(),
     STORAGE_KEY: z.string().min(1),
     DB_REDIS_CONNECTION_STRING: z.string().min(1),
+    TURNSTILE_SECRET_KEY: z.string().nullable().default(null),
     UNKEY_ROOT_KEY: z.string().nullable().default(null),
     EE_LICENSE_KEY: z.string().nullable().default(null),
     BILLING_KEY: z.string().nullable().default(null),

--- a/apps/platform/trpc/routers/authRouter/passkeyRouter.ts
+++ b/apps/platform/trpc/routers/authRouter/passkeyRouter.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod';
-import { router, publicRateLimitedProcedure } from '~platform/trpc/trpc';
+import {
+  router,
+  publicRateLimitedProcedure,
+  turnstileProcedure
+} from '~platform/trpc/trpc';
 import { eq } from '@u22n/database/orm';
 import { accounts } from '@u22n/database/schema';
 import { TRPCError } from '@trpc/server';
@@ -23,7 +27,9 @@ import { env } from '~platform/env';
 import { getCookie, setCookie } from 'hono/cookie';
 
 export const passkeyRouter = router({
+  // We use turnstile at start because there is no time to interact between starting and finishing the passkey registration
   signUpWithPasskeyStart: publicRateLimitedProcedure.signUpPasskeyStart
+    .unstable_concat(turnstileProcedure)
     .input(
       z.object({
         username: zodSchemas.username()
@@ -145,7 +151,9 @@ export const passkeyRouter = router({
       return { success: true };
     }),
 
+  // Same reason as  SignUp with passkey start
   generatePasskeyChallenge: publicRateLimitedProcedure.generatePasskeyChallenge
+    .unstable_concat(turnstileProcedure)
     .input(z.object({}))
     .query(async ({ ctx }) => {
       const { event } = ctx;

--- a/apps/platform/trpc/routers/authRouter/passwordRouter.ts
+++ b/apps/platform/trpc/routers/authRouter/passwordRouter.ts
@@ -3,7 +3,8 @@ import { Argon2id } from 'oslo/password';
 import {
   router,
   accountProcedure,
-  publicRateLimitedProcedure
+  publicRateLimitedProcedure,
+  turnstileProcedure
 } from '~platform/trpc/trpc';
 import { eq } from '@u22n/database/orm';
 import { accounts } from '@u22n/database/schema';
@@ -74,6 +75,7 @@ export const passwordRouter = router({
     }),
 
   signUpWithPassword2FA: publicRateLimitedProcedure.signUpWithPassword
+    .unstable_concat(turnstileProcedure)
     .input(
       z.object({
         username: zodSchemas.username(),
@@ -306,6 +308,7 @@ export const passwordRouter = router({
     }),
 
   signIn: publicRateLimitedProcedure.signInWithPassword
+    .unstable_concat(turnstileProcedure)
     .input(
       z.object({
         username: zodSchemas.username(2),

--- a/apps/platform/trpc/routers/authRouter/recoveryRouter.ts
+++ b/apps/platform/trpc/routers/authRouter/recoveryRouter.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod';
 import { Argon2id } from 'oslo/password';
-import { router, publicRateLimitedProcedure } from '~platform/trpc/trpc';
+import {
+  router,
+  publicRateLimitedProcedure,
+  turnstileProcedure
+} from '~platform/trpc/trpc';
 import { eq } from '@u22n/database/orm';
 import { accounts } from '@u22n/database/schema';
 import { nanoIdToken, zodSchemas } from '@u22n/utils/zodSchemas';
@@ -163,7 +167,10 @@ export const recoveryRouter = router({
           'Something went wrong, you should never see this message. Please report to team immediately.'
       });
     }),
+
+  // we only need to make sure that generate function is not abused
   getRecoveryVerificationToken: publicRateLimitedProcedure.recoverAccount
+    .unstable_concat(turnstileProcedure)
     .input(
       z
         .object({

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@calcom/embed-react": "^1.5.0",
     "@hookform/resolvers": "^3.6.0",
+    "@marsidev/react-turnstile": "^0.7.1",
     "@phosphor-icons/react": "^2.1.6",
     "@radix-ui/react-accordion": "^1.2.0",
     "@radix-ui/react-alert-dialog": "^1.1.1",

--- a/apps/web/src/app/(login)/login/page.tsx
+++ b/apps/web/src/app/(login)/login/page.tsx
@@ -29,10 +29,20 @@ import {
   InputOTPGroup,
   InputOTPSlot
 } from '@/src/components/shadcn-ui/input-otp';
+import {
+  TurnstileComponent,
+  turnstileEnabled
+} from '@/src/components/turnstile';
 
 const loginSchema = z.object({
   username: zodSchemas.username(2),
-  password: z.string().min(8, 'Password must be at least 8 characters')
+  password: z.string().min(8, 'Password must be at least 8 characters'),
+  turnstileToken: turnstileEnabled
+    ? z.string({
+        required_error:
+          'Waiting for Captcha. If you can see the Captcha, complete it manually'
+      })
+    : z.undefined()
 });
 
 export default function Page() {
@@ -109,6 +119,24 @@ export default function Page() {
                 )}
               />
               {error && <FormMessage>{error.message}</FormMessage>}
+
+              <FormField
+                control={form.control}
+                name="turnstileToken"
+                render={() => (
+                  <FormItem>
+                    <FormControl>
+                      <TurnstileComponent
+                        onSuccess={(value) =>
+                          form.setValue('turnstileToken', value)
+                        }
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
               <Button
                 className="w-full"
                 loading={isPending}

--- a/apps/web/src/app/join/secure/_components/modals.tsx
+++ b/apps/web/src/app/join/secure/_components/modals.tsx
@@ -27,8 +27,9 @@ export function PasskeyModal({
   open,
   onClose,
   onResolve,
-  username
-}: ModalComponent<{ username: string }>) {
+  username,
+  turnstileToken
+}: ModalComponent<{ username: string; turnstileToken?: string }>) {
   const [state, setState] = useState<string | null>(null);
 
   const getPasskeyChallenge =
@@ -39,7 +40,8 @@ export function PasskeyModal({
   const { error, loading, run } = useLoading(async () => {
     setState('Getting a passkey challenge from server');
     const { options, publicId } = await getPasskeyChallenge.fetch({
-      username
+      username,
+      turnstileToken
     });
     setState('Waiting for your passkey to respond');
     const passkeyData = await startRegistration(options).catch((e: Error) => {
@@ -101,8 +103,12 @@ export function PasswordModal({
   open,
   onClose,
   onResolve,
-  username
-}: ModalComponent<{ username: string }, { recoveryCode: string }>) {
+  username,
+  turnstileToken
+}: ModalComponent<
+  { username: string; turnstileToken?: string },
+  { recoveryCode: string }
+>) {
   const [password, setPassword] = useState<string>();
   const [twoFactorCode, setTwoFactorCode] = useState<string>('');
   const [step, setStep] = useState(1);
@@ -134,6 +140,7 @@ export function PasswordModal({
             password={password}
             twoFactorCode={twoFactorCode}
             setTwoFactorCode={setTwoFactorCode}
+            turnstileToken={turnstileToken}
             onResolve={onResolve}
             setStep={setStep}
           />
@@ -271,7 +278,8 @@ const PasswordModalStep2 = ({
   twoFactorCode,
   setTwoFactorCode,
   onResolve,
-  setStep
+  setStep,
+  turnstileToken
 }: {
   username: string;
   password?: string;
@@ -279,6 +287,7 @@ const PasswordModalStep2 = ({
   setTwoFactorCode: Dispatch<SetStateAction<string>>;
   onResolve: (e: { recoveryCode: string }) => void;
   setStep: Dispatch<SetStateAction<number>>;
+  turnstileToken?: string;
 }) => {
   const [error, setError] = useState<Error | null>(null);
 
@@ -309,7 +318,8 @@ const PasswordModalStep2 = ({
     const data = await signUpWithPassword.mutateAsync({
       username,
       password,
-      twoFactorCode
+      twoFactorCode,
+      turnstileToken
     });
 
     if (data.success) {

--- a/apps/web/src/components/turnstile.tsx
+++ b/apps/web/src/components/turnstile.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import React from 'react';
+import { env } from 'next-runtime-env';
+import {
+  Turnstile,
+  type TurnstileProps,
+  type TurnstileInstance
+} from '@marsidev/react-turnstile';
+import { useTheme } from 'next-themes';
+import { forwardRef } from 'react';
+
+const TURNSTILE_SITE_KEY = env('NEXT_PUBLIC_TURNSTILE_SITE_KEY');
+export const turnstileEnabled = Boolean(TURNSTILE_SITE_KEY);
+
+export const TurnstileComponent = forwardRef<
+  TurnstileInstance,
+  Omit<TurnstileProps, 'siteKey'>
+>(({ options, ...props }, ref) => {
+  const { resolvedTheme } = useTheme();
+  return turnstileEnabled ? (
+    <div className="flex items-center justify-center">
+      <Turnstile
+        ref={ref}
+        siteKey={TURNSTILE_SITE_KEY!}
+        options={{
+          theme: (resolvedTheme as 'dark' | 'light') ?? 'auto',
+          ...options
+        }}
+        {...props}
+      />
+    </div>
+  ) : null;
+});
+
+TurnstileComponent.displayName = 'TurnstileComponent';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -293,6 +293,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^3.6.0
         version: 3.6.0(react-hook-form@7.52.0(react@18.3.1))
+      '@marsidev/react-turnstile':
+        specifier: ^0.7.1
+        version: 0.7.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@phosphor-icons/react':
         specifier: ^2.1.6
         version: 2.1.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2340,6 +2343,12 @@ packages:
   '@mapbox/node-pre-gyp@1.0.11':
     resolution: {integrity: sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==}
     hasBin: true
+
+  '@marsidev/react-turnstile@0.7.1':
+    resolution: {integrity: sha512-SGa0cweJ2mP1RRi9oJJrlPpZHvlklLqu8tlXDLEbsQ/WExM8Ng9cr9439lZcnu8+tfeVpQIe8qFB1UU5uE+KlQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
@@ -11295,6 +11304,11 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  '@marsidev/react-turnstile@0.7.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     optional: true


### PR DESCRIPTION
## What does this PR do?

Adds turnstile on sign in/up and recovery pages. It is not problematic like we had in the Nuxt version.

Not setting the `TURNSTILE_SECRET_KEY` and `NEXT_PUBLIC_TURNSTILE_SITE_KEY` variables will disable it on platfrom and web respectively. Both needs to be either enabled or disabled for it to work.

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Tested my code in a local environment
- [ ] Commented on my code in hard-to-understand areas
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the UnInbox Docs if changes were necessary
