### PR TITLE
feat(next): add metadata to convo pages

### DIFF
--- a/apps/web/src/app/[orgShortCode]/convo/[convoId]/page-client.tsx
+++ b/apps/web/src/app/[orgShortCode]/convo/[convoId]/page-client.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { api } from '@/src/lib/trpc';
+import Link from 'next/link';
+import { type TypeId } from '@u22n/utils/typeid';
+import { useGlobalStore } from '@/src/providers/global-store-provider';
+import { useMemo } from 'react';
+import { formatParticipantData } from '../utils';
+import { env } from 'next-runtime-env';
+import { MessagesPanel } from './_components/messages-panel';
+import TopBar from './_components/top-bar';
+import { ReplyBox } from './_components/reply-box';
+import { Button } from '@/src/components/shadcn-ui/button';
+
+const STORAGE_URL = env('NEXT_PUBLIC_STORAGE_URL');
+
+export default function ConvoView({ convoId }: { convoId: TypeId<'convos'> }) {
+  const orgShortCode = useGlobalStore((state) => state.currentOrg.shortCode);
+  const {
+    data: convoData,
+    isLoading: convoDataLoading,
+    error: convoError
+  } = api.convos.getConvo.useQuery({
+    orgShortCode,
+    convoPublicId: convoId
+  });
+
+  const attachments = useMemo(() => {
+    if (!convoData) return [];
+    return convoData.data.attachments
+      .filter((f) => !f.inline)
+      .map((attachment) => ({
+        name: attachment.fileName,
+        url: `${STORAGE_URL}/attachment/${orgShortCode}/${attachment.publicId}/${attachment.fileName}`,
+        type: attachment.type,
+        publicId: attachment.publicId
+      }));
+  }, [convoData, orgShortCode]);
+
+  const participantOwnPublicId = convoData?.ownParticipantPublicId;
+  const convoHidden = useMemo(
+    () =>
+      convoData
+        ? convoData?.data.participants.find(
+            (p) => p.publicId === participantOwnPublicId
+          )?.hidden ?? false
+        : null,
+    [convoData, participantOwnPublicId]
+  );
+
+  const formattedParticipants = useMemo(() => {
+    const formattedParticipantsData: NonNullable<
+      ReturnType<typeof formatParticipantData>
+    >[] = [];
+    if (convoData?.data.participants) {
+      for (const participant of convoData.data.participants) {
+        const formattedParticipant = formatParticipantData(participant);
+        if (!formattedParticipant) continue;
+        formattedParticipantsData.push(formattedParticipant);
+      }
+    }
+    return formattedParticipantsData;
+  }, [convoData?.data.participants]);
+
+  if (convoError && convoError.data?.code === 'NOT_FOUND') {
+    return <ConvoNotFound />;
+  }
+
+  return (
+    <div className="flex h-full max-h-full w-full max-w-full flex-col overflow-hidden rounded-2xl">
+      <TopBar
+        isConvoLoading={convoDataLoading}
+        convoId={convoId}
+        convoHidden={convoHidden}
+        subjects={convoData?.data.subjects}
+        participants={formattedParticipants}
+        attachments={attachments}
+      />
+      <div className="flex h-full w-full min-w-96 flex-col">
+        {convoDataLoading || !participantOwnPublicId ? (
+          <span>Loading</span>
+        ) : (
+          <MessagesPanel
+            convoId={convoId}
+            formattedParticipants={formattedParticipants}
+            participantOwnPublicId={
+              participantOwnPublicId as TypeId<'convoParticipants'>
+            }
+          />
+        )}
+      </div>
+      <ReplyBox convoId={convoId} />
+    </div>
+  );
+}
+
+export function ConvoNotFound() {
+  const orgShortCode = useGlobalStore((state) => state.currentOrg.shortCode);
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center">
+      <div>
+        <span>Convo Not Found</span>
+        <span>
+          The convo you are looking for does not exist. Please check the URL and
+          try again.
+        </span>
+        <Link href={`/${orgShortCode}/convo`}>
+          <Button>Go back to Convos</Button>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/[orgShortCode]/convo/[convoId]/page.tsx
+++ b/apps/web/src/app/[orgShortCode]/convo/[convoId]/page.tsx
@@ -1,124 +1,46 @@
-'use client';
+import { validateTypeId } from '@u22n/utils/typeid';
+import ConvoView, { ConvoNotFound } from './page-client';
+import type { Metadata } from 'next';
+import { serverApi } from '@/src/lib/trpc.server';
 
-import { api } from '@/src/lib/trpc';
-import Link from 'next/link';
-import { type TypeId, validateTypeId } from '@u22n/utils/typeid';
-import { useGlobalStore } from '@/src/providers/global-store-provider';
-import { useMemo } from 'react';
-import { formatParticipantData } from '../utils';
-import { env } from 'next-runtime-env';
-import { MessagesPanel } from './_components/messages-panel';
-import TopBar from './_components/top-bar';
-import { ReplyBox } from './_components/reply-box';
-import { Button } from '@/src/components/shadcn-ui/button';
-
-const STORAGE_URL = env('NEXT_PUBLIC_STORAGE_URL');
-
-export default function Page({
-  params: { convoId }
-}: {
-  params: { convoId: string };
-}) {
-  if (!validateTypeId('convos', convoId)) {
-    return <ConvoNotFound />;
-  }
-  return <ConvoView convoId={convoId} />;
+interface ConvoPageParams {
+  orgShortCode: string;
+  convoId: string;
 }
 
-function ConvoView({ convoId }: { convoId: TypeId<'convos'> }) {
-  const orgShortCode = useGlobalStore((state) => state.currentOrg.shortCode);
-  const {
-    data: convoData,
-    isLoading: convoDataLoading,
-    error: convoError
-  } = api.convos.getConvo.useQuery({
-    orgShortCode,
-    convoPublicId: convoId
+export async function generateMetadata({
+  params
+}: {
+  params: ConvoPageParams;
+}): Promise<Metadata> {
+  const currentConvo = await serverApi.convos.getConvo.query({
+    orgShortCode: params.orgShortCode,
+    convoPublicId: params.convoId
   });
 
-  const attachments = useMemo(() => {
-    if (!convoData) return [];
-    return convoData.data.attachments
-      .filter((f) => !f.inline)
-      .map((attachment) => ({
-        name: attachment.fileName,
-        url: `${STORAGE_URL}/attachment/${orgShortCode}/${attachment.publicId}/${attachment.fileName}`,
-        type: attachment.type,
-        publicId: attachment.publicId
-      }));
-  }, [convoData, orgShortCode]);
+  if (!currentConvo) {
+    return {
+      title: 'Convo not found',
+      description: 'Convo not found',
+      icons: '/logo.png'
+    };
+  }
 
-  const participantOwnPublicId = convoData?.ownParticipantPublicId;
-  const convoHidden = useMemo(
-    () =>
-      convoData
-        ? convoData?.data.participants.find(
-            (p) => p.publicId === participantOwnPublicId
-          )?.hidden ?? false
-        : null,
-    [convoData, participantOwnPublicId]
-  );
+  const title = currentConvo.data.subjects[0]
+    ? currentConvo.data.subjects[0]?.subject
+    : 'UnInbox';
 
-  const formattedParticipants = useMemo(() => {
-    const formattedParticipantsData: NonNullable<
-      ReturnType<typeof formatParticipantData>
-    >[] = [];
-    if (convoData?.data.participants) {
-      for (const participant of convoData.data.participants) {
-        const formattedParticipant = formatParticipantData(participant);
-        if (!formattedParticipant) continue;
-        formattedParticipantsData.push(formattedParticipant);
-      }
-    }
-    return formattedParticipantsData;
-  }, [convoData?.data.participants]);
+  return {
+    title: `Convo | ${title}`,
+    description: 'View and reply to this conversation',
+    icons: '/logo.png'
+  };
+}
 
-  if (convoError && convoError.data?.code === 'NOT_FOUND') {
+export default function ConvoPage({ params }: { params: ConvoPageParams }) {
+  if (!validateTypeId('convos', params.convoId)) {
     return <ConvoNotFound />;
   }
 
-  return (
-    <div className="flex h-full max-h-full w-full max-w-full flex-col overflow-hidden rounded-2xl">
-      <TopBar
-        isConvoLoading={convoDataLoading}
-        convoId={convoId}
-        convoHidden={convoHidden}
-        subjects={convoData?.data.subjects}
-        participants={formattedParticipants}
-        attachments={attachments}
-      />
-      <div className="flex h-full w-full min-w-96 flex-col">
-        {convoDataLoading || !participantOwnPublicId ? (
-          <span>Loading</span>
-        ) : (
-          <MessagesPanel
-            convoId={convoId}
-            formattedParticipants={formattedParticipants}
-            participantOwnPublicId={
-              participantOwnPublicId as TypeId<'convoParticipants'>
-            }
-          />
-        )}
-      </div>
-      <ReplyBox convoId={convoId} />
-    </div>
-  );
-}
-
-function ConvoNotFound() {
-  const orgShortCode = useGlobalStore((state) => state.currentOrg.shortCode);
-  return (
-    <div className="flex h-full w-full flex-col items-center justify-center">
-      <div>
-        <span>Convo Not Found</span>
-        <span>
-          The convo you are looking for does not exist. Please check the URL and
-          try again.
-        </span>
-        <Link href={`/${orgShortCode}/convo`}>
-          <Button>Go back to Convos</Button>
-        </Link>
-      </div>
-    </div>
-  );
+  return <ConvoView convoId={params.convoId} />;
 }

--- a/apps/web/src/app/[orgShortCode]/convo/new/page.tsx
+++ b/apps/web/src/app/[orgShortCode]/convo/new/page.tsx
@@ -1,5 +1,12 @@
+import type { Metadata } from 'next';
 import React from 'react';
 import CreateConvoForm from '../_components/create-convo-form';
+
+export const metadata: Metadata = {
+  title: 'UnInbox | Create Convo',
+  description: 'Open Source Email service',
+  icons: '/logo.png'
+};
 
 export default function Page() {
   return <CreateConvoForm />;


### PR DESCRIPTION
## What does this PR do?

Hi everyone! This PR adds document titles and metadata to each page in the convo route indicating information about the `page/convo`. I closed the first PR to make it more focused, since applying this logic in the `settings` path would have implied too many changes. If this one is merged, I can open another one for the `settings` routes using the same logic.

Fixes https://github.com/un/inbox/issues/215

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

### Required

- [x] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Tested my code in a local environment
- [ ] Commented on my code in hard-to-understand areas
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the UnInbox Docs if changes were necessary
