### PR TITLE
feat: disable sending emails from unverified email identities

### DIFF
--- a/apps/platform/trpc/routers/convoRouter/convoRouter.ts
+++ b/apps/platform/trpc/routers/convoRouter/convoRouter.ts
@@ -110,6 +110,45 @@ export const convoRouter = router({
         firstMessageType
       } = input;
 
+      // if there is a send as email identity, check if that email identity is enabled
+      if (sendAsEmailIdentityPublicId) {
+        const emailIdentityResponse = await db.query.emailIdentities.findFirst({
+          where: and(
+            eq(emailIdentities.orgId, orgId),
+            eq(emailIdentities.publicId, sendAsEmailIdentityPublicId)
+          ),
+          columns: {},
+          with: {
+            domain: {
+              columns: {
+                domainStatus: true,
+                sendingMode: true
+              }
+            }
+          }
+        });
+
+        if (!emailIdentityResponse) {
+          throw new TRPCError({
+            code: 'NOT_FOUND',
+            message: 'Send as email identity not found'
+          });
+        }
+
+        if (emailIdentityResponse.domain) {
+          if (
+            emailIdentityResponse.domain.domainStatus !== 'active' ||
+            emailIdentityResponse.domain.sendingMode === 'disabled'
+          ) {
+            throw new TRPCError({
+              code: 'UNPROCESSABLE_CONTENT',
+              message:
+                'You cant send from that email address due to a configuration issue. Please contact your administrator or select a different email identity.'
+            });
+          }
+        }
+      }
+
       const message: tiptapVue3.JSONContent = parse(messageString);
       let convoParticipantToPublicId: TypeId<'convoParticipants'>;
       let convoMessageToNewContactPublicId: TypeId<'contacts'>;
@@ -763,6 +802,45 @@ export const convoRouter = router({
         message: messageString,
         messageType
       } = input;
+
+      // if there is a send as email identity, check if that email identity is enabled
+      if (sendAsEmailIdentityPublicId) {
+        const emailIdentityResponse = await db.query.emailIdentities.findFirst({
+          where: and(
+            eq(emailIdentities.orgId, orgId),
+            eq(emailIdentities.publicId, sendAsEmailIdentityPublicId)
+          ),
+          columns: {},
+          with: {
+            domain: {
+              columns: {
+                domainStatus: true,
+                sendingMode: true
+              }
+            }
+          }
+        });
+
+        if (!emailIdentityResponse) {
+          throw new TRPCError({
+            code: 'NOT_FOUND',
+            message: 'Send as email identity not found'
+          });
+        }
+
+        if (emailIdentityResponse.domain) {
+          if (
+            emailIdentityResponse.domain.domainStatus !== 'active' ||
+            emailIdentityResponse.domain.sendingMode === 'disabled'
+          ) {
+            throw new TRPCError({
+              code: 'UNPROCESSABLE_CONTENT',
+              message:
+                'You cant send from that email address due to a configuration issue. Please contact your administrator or select a different email identity.'
+            });
+          }
+        }
+      }
 
       const message: tiptapVue3.JSONContent = parse(messageString);
 

--- a/apps/web/src/components/shadcn-ui/tooltip.tsx
+++ b/apps/web/src/components/shadcn-ui/tooltip.tsx
@@ -13,15 +13,17 @@ const TooltipContent = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
 >(({ className, sideOffset = 4, ...props }, ref) => (
-  <TooltipPrimitive.Content
-    ref={ref}
-    sideOffset={sideOffset}
-    className={cn(
-      'bg-base-12 text-base-1 animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 overflow-hidden rounded-md px-3 py-1.5 text-xs',
-      className
-    )}
-    {...props}
-  />
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        'bg-base-12 text-base-1 animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-[1000] overflow-hidden rounded-md px-3 py-1.5 text-xs',
+        className
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
 ));
 TooltipContent.displayName = TooltipPrimitive.Content.displayName;
 


### PR DESCRIPTION
## What does this PR do?

When a email is created with a domain that is not yet verified, disable sending emails form that domain.

On frontend show a tooltip that the email identity is disabled. on platform add checks to throw error if provided email identity is disabled

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Tested my code in a local environment
- [ ] Commented on my code in hard-to-understand areas
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the UnInbox Docs if changes were necessary
