### PR TITLE
feat: web app env is now type safe and auto prefixed

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -98,15 +98,6 @@ UNKEY_ROOT_KEY=""
 TURNSTILE_SITE_KEY=
 TURNSTILE_SECRET_KEY=
 
-############################ NEXT_PUBLIC VARIABLES ############################
-NEXT_PUBLIC_WEBAPP_URL=http://localhost:3000
-NEXT_PUBLIC_STORAGE_URL=http://localhost:3200
-NEXT_PUBLIC_PLATFORM_URL=http://localhost:3300
-NEXT_PUBLIC_REALTIME_APP_KEY=secretsecretsecret
-NEXT_PUBLIC_REALTIME_HOST=localhost
-NEXT_PUBLIC_REALTIME_PORT=3904
-NEXT_PUBLIC_TUNSTILE_SITE_KEY=
-
 ########################## WORKER APP VARIABLES ################################
 WORKER_URL=http://localhost:3400
 WORKER_ACCESS_KEY=secretsecretsecretsecretsecretsecret

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,3 +1,6 @@
+// import the env file to validate the environment variables before starting the app
+await import('./src/env.js');
+
 /** @type {import("next").NextConfig} */
 const config = {
   // Checked in CI anyways
@@ -6,15 +9,6 @@ const config = {
   },
   eslint: {
     ignoreDuringBuilds: true
-  },
-  experimental: {
-    staleTimes: {
-      dynamic: 0,
-      static: 0
-    }
-  },
-  env: {
-    NEXT_PUBLIC_EE_ENABLED: process.env.EE_LICENSE_KEY ? 'true' : 'false'
   }
 };
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -35,6 +35,7 @@
     "@radix-ui/react-toggle-group": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.1.0",
     "@simplewebauthn/browser": "^10.0.0",
+    "@t3-oss/env-core": "^0.10.1",
     "@tailwindcss/typography": "^0.5.13",
     "@tanstack/react-form": "^0.19.5",
     "@tanstack/react-query": "^5.45.1",

--- a/apps/web/src/app/[orgShortCode]/_components/sidebar-content.tsx
+++ b/apps/web/src/app/[orgShortCode]/_components/sidebar-content.tsx
@@ -21,7 +21,6 @@ import {
   DropdownMenuPortal,
   DropdownMenuGroup
 } from '@/src/components/shadcn-ui/dropdown-menu';
-
 import {
   Check,
   SignOut,
@@ -40,7 +39,6 @@ import {
   Question,
   User
 } from '@phosphor-icons/react';
-import { env } from 'next-runtime-env';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useMemo } from 'react';
@@ -54,6 +52,7 @@ import {
   ToggleGroup,
   ToggleGroupItem
 } from '@/src/components/shadcn-ui/toggle-group';
+import { env } from '@/src/env';
 
 export default function SidebarContent() {
   const orgShortCode = useGlobalStore((state) => state.currentOrg.shortCode);
@@ -94,8 +93,6 @@ export default function SidebarContent() {
   );
 }
 
-const PLATFORM_URL = env('NEXT_PUBLIC_PLATFORM_URL');
-
 function OrgMenu() {
   const setCurrentOrg = useGlobalStore((state) => state.setCurrentOrg);
   const currentOrg = useGlobalStore((state) => state.currentOrg);
@@ -132,7 +129,7 @@ function OrgMenu() {
 
   const { run: logOut, loading: loggingOut } = useLoading(
     async () => {
-      await fetch(`${PLATFORM_URL}/auth/logout`, {
+      await fetch(`${env.NEXT_PUBLIC_PLATFORM_URL}/auth/logout`, {
         method: 'POST',
         credentials: 'include'
       });

--- a/apps/web/src/app/[orgShortCode]/convo/[convoId]/page-client.tsx
+++ b/apps/web/src/app/[orgShortCode]/convo/[convoId]/page-client.tsx
@@ -6,13 +6,11 @@ import { type TypeId } from '@u22n/utils/typeid';
 import { useGlobalStore } from '@/src/providers/global-store-provider';
 import { useMemo } from 'react';
 import { formatParticipantData } from '../utils';
-import { env } from 'next-runtime-env';
 import { MessagesPanel } from './_components/messages-panel';
 import TopBar from './_components/top-bar';
 import { ReplyBox } from './_components/reply-box';
 import { Button } from '@/src/components/shadcn-ui/button';
-
-const STORAGE_URL = env('NEXT_PUBLIC_STORAGE_URL');
+import { env } from '@/src/env';
 
 export default function ConvoView({ convoId }: { convoId: TypeId<'convos'> }) {
   const orgShortCode = useGlobalStore((state) => state.currentOrg.shortCode);
@@ -31,7 +29,7 @@ export default function ConvoView({ convoId }: { convoId: TypeId<'convos'> }) {
       .filter((f) => !f.inline)
       .map((attachment) => ({
         name: attachment.fileName,
-        url: `${STORAGE_URL}/attachment/${orgShortCode}/${attachment.publicId}/${attachment.fileName}`,
+        url: `${env.NEXT_PUBLIC_STORAGE_URL}/attachment/${orgShortCode}/${attachment.publicId}/${attachment.fileName}`,
         type: attachment.type,
         publicId: attachment.publicId
       }));

--- a/apps/web/src/app/[orgShortCode]/settings/org/users/invites/_components/columns.tsx
+++ b/apps/web/src/app/[orgShortCode]/settings/org/users/invites/_components/columns.tsx
@@ -17,9 +17,7 @@ import {
   TooltipContent
 } from '@/src/components/shadcn-ui/tooltip';
 import { CopyButton } from '@/src/components/copy-button';
-import { env } from 'next-runtime-env';
-
-const WEBAPP_URL = env('NEXT_PUBLIC_WEBAPP_URL');
+import { env } from '@/src/env';
 
 type Member =
   RouterOutputs['org']['users']['invites']['viewInvites']['invites'][number];
@@ -100,10 +98,10 @@ export const columns: ColumnDef<Member>[] = [
           <ScrollArea
             className="w-32"
             type="hover">
-            <span>{`${WEBAPP_URL}/join/invite/${inviteCode}`}</span>
+            <span>{`${env.NEXT_PUBLIC_WEBAPP_URL}/join/invite/${inviteCode}`}</span>
           </ScrollArea>
           <CopyButton
-            text={`${WEBAPP_URL}/join/invite/${inviteCode}`}
+            text={`${env.NEXT_PUBLIC_WEBAPP_URL}/join/invite/${inviteCode}`}
             iconSize={12}
           />
         </div>

--- a/apps/web/src/components/shared/attachment-button.tsx
+++ b/apps/web/src/components/shared/attachment-button.tsx
@@ -3,11 +3,11 @@ import { useGlobalStore } from '@/src/providers/global-store-provider';
 import { type TypeId } from '@u22n/utils/typeid';
 import { type PrimitiveAtom, useAtom } from 'jotai';
 import { Plus } from '@phosphor-icons/react';
-import { env } from 'next-runtime-env';
 import { useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { Badge } from '@/src/components/shadcn-ui/badge';
 import { Button } from '@/src/components/shadcn-ui/button';
+import { env } from '@/src/env';
 
 export type ConvoAttachmentUpload = {
   fileName: string;
@@ -25,7 +25,6 @@ type PreSignedData = {
   signedUrl: string;
 };
 
-const STORAGE_URL = env('NEXT_PUBLIC_STORAGE_URL');
 const FILE_SIZE_LIMIT = 15_000_000; // 15MB
 
 export function AttachmentButton({ attachmentsAtom }: AttachmentButtonProps) {
@@ -62,7 +61,7 @@ export function AttachmentButton({ attachmentsAtom }: AttachmentButtonProps) {
     const results = await Promise.allSettled(
       files.map(async (file) => {
         const preSignedData = (await fetch(
-          `${STORAGE_URL}/api/attachments/presign?orgShortCode=${currentOrgShortCode}&filename=${file.name}`,
+          `${env.NEXT_PUBLIC_STORAGE_URL}/api/attachments/presign?orgShortCode=${currentOrgShortCode}&filename=${file.name}`,
           {
             method: 'GET',
             credentials: 'include'

--- a/apps/web/src/components/shared/attachments.tsx
+++ b/apps/web/src/components/shared/attachments.tsx
@@ -1,6 +1,5 @@
 import { type TypeId } from '@u22n/utils/typeid';
 import { useCallback, useMemo, useState } from 'react';
-import { env } from 'next-runtime-env';
 import { toast } from 'sonner';
 import { cn, prettyBytes } from '../../lib/utils';
 import { useGlobalStore } from '../../providers/global-store-provider';
@@ -18,6 +17,7 @@ import {
   X
 } from '@phosphor-icons/react';
 import { type VariantProps, cva } from 'class-variance-authority';
+import { env } from '@/src/env';
 
 export type Attachment = {
   filename: string;
@@ -35,7 +35,6 @@ export type ConvoAttachmentUpload = {
   type: string;
 };
 
-const STORAGE_URL = env('NEXT_PUBLIC_STORAGE_URL');
 const FILE_SIZE_LIMIT = 15_000_000; // 15MB
 
 export function toTrpcUploadFormat(attachments: Attachment[]) {
@@ -71,7 +70,7 @@ export function useAttachmentUploader(defaultList?: Attachment[]) {
     async (file: File) => {
       setPrefetching(true);
       const preSignedData = (await fetch(
-        `${STORAGE_URL}/api/attachments/presign?orgShortCode=${orgShortCode}&filename=${file.name}`,
+        `${env.NEXT_PUBLIC_STORAGE_URL}/api/attachments/presign?orgShortCode=${orgShortCode}&filename=${file.name}`,
         {
           method: 'GET',
           credentials: 'include'

--- a/apps/web/src/components/turnstile.tsx
+++ b/apps/web/src/components/turnstile.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React from 'react';
-import { env } from 'next-runtime-env';
 import {
   Turnstile,
   type TurnstileProps,
@@ -9,9 +8,9 @@ import {
 } from '@marsidev/react-turnstile';
 import { useTheme } from 'next-themes';
 import { forwardRef } from 'react';
+import { env } from '../env';
 
-const TURNSTILE_SITE_KEY = env('NEXT_PUBLIC_TURNSTILE_SITE_KEY');
-export const turnstileEnabled = Boolean(TURNSTILE_SITE_KEY);
+export const turnstileEnabled = Boolean(env.NEXT_PUBLIC_TURNSTILE_SITE_KEY);
 
 export const TurnstileComponent = forwardRef<
   TurnstileInstance,
@@ -22,7 +21,7 @@ export const TurnstileComponent = forwardRef<
     <div className="flex items-center justify-center">
       <Turnstile
         ref={ref}
-        siteKey={TURNSTILE_SITE_KEY!}
+        siteKey={env.NEXT_PUBLIC_TURNSTILE_SITE_KEY!}
         options={{
           theme: (resolvedTheme as 'dark' | 'light') ?? 'auto',
           ...options

--- a/apps/web/src/env.js
+++ b/apps/web/src/env.js
@@ -1,0 +1,50 @@
+import { z } from 'zod';
+import { createEnv } from '@t3-oss/env-core';
+
+const IS_BROWSER = typeof window !== 'undefined';
+
+// Don't worry about this block, it is tree-shaken out in the browser
+if (!IS_BROWSER) {
+  // Let the client know if the EE is enabled but don't expose the license key
+  process.env.EE_ENABLED = Boolean(process.env.EE_LICENSE_KEY)
+    ? 'true'
+    : 'false';
+
+  // DON'T ADD ANY SENSITIVE ENVIRONMENT VARIABLES HERE
+  // All variables defined here will be exposed to the client
+  const PUBLIC_ENV_LIST = [
+    'WEBAPP_URL',
+    'STORAGE_URL',
+    'PLATFORM_URL',
+    'REALTIME_APP_KEY',
+    'REALTIME_HOST',
+    'REALTIME_PORT',
+    'TURNSTILE_SITE_KEY',
+    'EE_ENABLED'
+  ];
+
+  PUBLIC_ENV_LIST.forEach((key) => {
+    const prefixedKey = `NEXT_PUBLIC_${key}`;
+    process.env[prefixedKey] = process.env[key];
+  });
+}
+
+export const env = createEnv({
+  client: {
+    NEXT_PUBLIC_WEBAPP_URL: z.string().url(),
+    NEXT_PUBLIC_STORAGE_URL: z.string().url(),
+    NEXT_PUBLIC_PLATFORM_URL: z.string().url(),
+    NEXT_PUBLIC_REALTIME_APP_KEY: z.string(),
+    NEXT_PUBLIC_REALTIME_HOST: z.string(),
+    NEXT_PUBLIC_REALTIME_PORT: z.coerce.number(),
+    NEXT_PUBLIC_TURNSTILE_SITE_KEY: z.string().optional(),
+    NEXT_PUBLIC_EE_ENABLED: z
+      .enum(['true', 'false'])
+      .optional()
+      .transform((value) => value === 'true')
+  },
+  // process.env is added here to allow access while on server, it is tree-shaken out in the browser
+  // if you check in the browser, you will see runtimeEnv is set to window.__ENV only
+  runtimeEnv: IS_BROWSER ? window.__ENV : process.env,
+  clientPrefix: 'NEXT_PUBLIC_'
+});

--- a/apps/web/src/lib/trpc.tsx
+++ b/apps/web/src/lib/trpc.tsx
@@ -10,7 +10,7 @@ import { type PropsWithChildren, useState } from 'react';
 import SuperJSON from 'superjson';
 import type { TrpcPlatformRouter } from '@u22n/platform/trpc';
 import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server';
-import { env } from 'next-runtime-env';
+import { env } from '../env';
 
 const createQueryClient = () =>
   new QueryClient({
@@ -36,7 +36,6 @@ export const api = createTRPCReact<TrpcPlatformRouter>();
 
 export function TRPCReactProvider({ children }: PropsWithChildren) {
   const queryClient = getQueryClient();
-  const PLATFORM_URL = env('NEXT_PUBLIC_PLATFORM_URL');
 
   const [trpcClient] = useState(() =>
     api.createClient({
@@ -47,7 +46,7 @@ export function TRPCReactProvider({ children }: PropsWithChildren) {
             (op.direction === 'down' && op.result instanceof Error)
         }),
         httpBatchLink({
-          url: `${PLATFORM_URL}/trpc`,
+          url: `${env.NEXT_PUBLIC_PLATFORM_URL}/trpc`,
           transformer: SuperJSON,
           fetch: (input, init) =>
             fetch(input, { ...init, credentials: 'include' })
@@ -68,9 +67,8 @@ export function TRPCReactProvider({ children }: PropsWithChildren) {
 }
 
 export async function isAuthenticated() {
-  const PLATFORM_URL = env('NEXT_PUBLIC_PLATFORM_URL');
   try {
-    const data = (await fetch(`${PLATFORM_URL}/auth/status`, {
+    const data = (await fetch(`${env.NEXT_PUBLIC_PLATFORM_URL}/auth/status`, {
       credentials: 'include'
     }).then((r) => r.json())) as {
       authStatus: 'authenticated' | 'unauthenticated';

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -1,7 +1,7 @@
 import { twMerge } from 'tailwind-merge';
 import clsx, { type ClassValue } from 'clsx';
 import { type TypeId } from '@u22n/utils/typeid';
-import { env } from 'next-runtime-env';
+import { env } from '../env';
 
 export const cn = (...input: ClassValue[]) => twMerge(clsx(input));
 
@@ -18,7 +18,6 @@ export const downloadAsFile = (filename: string, content: string) => {
   document.body.removeChild(element);
 };
 
-const STORAGE_URL = env('NEXT_PUBLIC_STORAGE_URL');
 export const generateAvatarUrl = ({
   publicId,
   avatarTimestamp,
@@ -43,7 +42,7 @@ export const generateAvatarUrl = ({
     return null;
   }
   const epochTs = new Date(avatarTimestamp).getTime() / 1000;
-  return `${STORAGE_URL}/avatar/${publicId}/${
+  return `${env.NEXT_PUBLIC_STORAGE_URL}/avatar/${publicId}/${
     size ? size : '5xl'
   }?t=${epochTs}`;
 };

--- a/apps/web/src/providers/realtime-provider.tsx
+++ b/apps/web/src/providers/realtime-provider.tsx
@@ -7,15 +7,10 @@ import {
 } from 'react';
 import RealtimeClient from '@u22n/realtime/client';
 import { useGlobalStore } from './global-store-provider';
-import { env } from 'next-runtime-env';
 import { toast } from 'sonner';
+import { env } from '../env';
 
 const realtimeContext = createContext<RealtimeClient | null>(null);
-
-const appKey = env('NEXT_PUBLIC_REALTIME_APP_KEY')!;
-const host = env('NEXT_PUBLIC_REALTIME_HOST')!;
-const port = Number(env('NEXT_PUBLIC_REALTIME_PORT')!);
-const PLATFORM_URL = env('NEXT_PUBLIC_PLATFORM_URL')!;
 
 export function RealtimeProvider({ children }: PropsWithChildren) {
   const orgShortCode = useGlobalStore((state) => state.currentOrg.shortCode);
@@ -23,10 +18,10 @@ export function RealtimeProvider({ children }: PropsWithChildren) {
   const [client] = useState(
     () =>
       new RealtimeClient({
-        appKey,
-        host,
-        port,
-        authEndpoint: `${PLATFORM_URL}/realtime/auth`
+        appKey: env.NEXT_PUBLIC_REALTIME_APP_KEY,
+        host: env.NEXT_PUBLIC_REALTIME_HOST,
+        port: env.NEXT_PUBLIC_REALTIME_PORT,
+        authEndpoint: `${env.NEXT_PUBLIC_PLATFORM_URL}/realtime/auth`
       })
   );
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -368,6 +368,9 @@ importers:
       '@simplewebauthn/browser':
         specifier: ^10.0.0
         version: 10.0.0
+      '@t3-oss/env-core':
+        specifier: ^0.10.1
+        version: 0.10.1(typescript@5.5.2)(zod@3.23.8)
       '@tailwindcss/typography':
         specifier: ^0.5.13
         version: 0.5.13(tailwindcss@3.4.4)
@@ -6755,10 +6758,10 @@ snapshots:
       '@aws-crypto/sha1-browser': 5.2.0
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/client-sso-oidc': 3.600.0(@aws-sdk/client-sts@3.600.0)
-      '@aws-sdk/client-sts': 3.600.0
+      '@aws-sdk/client-sso-oidc': 3.600.0
+      '@aws-sdk/client-sts': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)
       '@aws-sdk/core': 3.598.0
-      '@aws-sdk/credential-provider-node': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0)
+      '@aws-sdk/credential-provider-node': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0(@aws-sdk/client-sso-oidc@3.600.0))
       '@aws-sdk/middleware-bucket-endpoint': 3.598.0
       '@aws-sdk/middleware-expect-continue': 3.598.0
       '@aws-sdk/middleware-flexible-checksums': 3.598.0
@@ -6813,13 +6816,13 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0)':
+  '@aws-sdk/client-sso-oidc@3.600.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/client-sts': 3.600.0
+      '@aws-sdk/client-sts': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)
       '@aws-sdk/core': 3.598.0
-      '@aws-sdk/credential-provider-node': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0)
+      '@aws-sdk/credential-provider-node': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0(@aws-sdk/client-sso-oidc@3.600.0))
       '@aws-sdk/middleware-host-header': 3.598.0
       '@aws-sdk/middleware-logger': 3.598.0
       '@aws-sdk/middleware-recursion-detection': 3.598.0
@@ -6856,7 +6859,6 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.6.3
     transitivePeerDependencies:
-      - '@aws-sdk/client-sts'
       - aws-crt
 
   '@aws-sdk/client-sso@3.598.0':
@@ -6902,13 +6904,13 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sts@3.600.0':
+  '@aws-sdk/client-sts@3.600.0(@aws-sdk/client-sso-oidc@3.600.0)':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/client-sso-oidc': 3.600.0(@aws-sdk/client-sts@3.600.0)
+      '@aws-sdk/client-sso-oidc': 3.600.0
       '@aws-sdk/core': 3.598.0
-      '@aws-sdk/credential-provider-node': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0)
+      '@aws-sdk/credential-provider-node': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0(@aws-sdk/client-sso-oidc@3.600.0))
       '@aws-sdk/middleware-host-header': 3.598.0
       '@aws-sdk/middleware-logger': 3.598.0
       '@aws-sdk/middleware-recursion-detection': 3.598.0
@@ -6945,6 +6947,7 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.6.3
     transitivePeerDependencies:
+      - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
   '@aws-sdk/core@3.598.0':
@@ -6976,14 +6979,14 @@ snapshots:
       '@smithy/util-stream': 3.0.4
       tslib: 2.6.3
 
-  '@aws-sdk/credential-provider-ini@3.598.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0)':
+  '@aws-sdk/credential-provider-ini@3.598.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0(@aws-sdk/client-sso-oidc@3.600.0))':
     dependencies:
-      '@aws-sdk/client-sts': 3.600.0
+      '@aws-sdk/client-sts': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)
       '@aws-sdk/credential-provider-env': 3.598.0
       '@aws-sdk/credential-provider-http': 3.598.0
       '@aws-sdk/credential-provider-process': 3.598.0
-      '@aws-sdk/credential-provider-sso': 3.598.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))
-      '@aws-sdk/credential-provider-web-identity': 3.598.0(@aws-sdk/client-sts@3.600.0)
+      '@aws-sdk/credential-provider-sso': 3.598.0(@aws-sdk/client-sso-oidc@3.600.0)
+      '@aws-sdk/credential-provider-web-identity': 3.598.0(@aws-sdk/client-sts@3.600.0(@aws-sdk/client-sso-oidc@3.600.0))
       '@aws-sdk/types': 3.598.0
       '@smithy/credential-provider-imds': 3.1.2
       '@smithy/property-provider': 3.1.2
@@ -6994,14 +6997,14 @@ snapshots:
       - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
-  '@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0)':
+  '@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0(@aws-sdk/client-sso-oidc@3.600.0))':
     dependencies:
       '@aws-sdk/credential-provider-env': 3.598.0
       '@aws-sdk/credential-provider-http': 3.598.0
-      '@aws-sdk/credential-provider-ini': 3.598.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0)
+      '@aws-sdk/credential-provider-ini': 3.598.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0(@aws-sdk/client-sso-oidc@3.600.0))
       '@aws-sdk/credential-provider-process': 3.598.0
-      '@aws-sdk/credential-provider-sso': 3.598.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))
-      '@aws-sdk/credential-provider-web-identity': 3.598.0(@aws-sdk/client-sts@3.600.0)
+      '@aws-sdk/credential-provider-sso': 3.598.0(@aws-sdk/client-sso-oidc@3.600.0)
+      '@aws-sdk/credential-provider-web-identity': 3.598.0(@aws-sdk/client-sts@3.600.0(@aws-sdk/client-sso-oidc@3.600.0))
       '@aws-sdk/types': 3.598.0
       '@smithy/credential-provider-imds': 3.1.2
       '@smithy/property-provider': 3.1.2
@@ -7021,10 +7024,10 @@ snapshots:
       '@smithy/types': 3.2.0
       tslib: 2.6.3
 
-  '@aws-sdk/credential-provider-sso@3.598.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))':
+  '@aws-sdk/credential-provider-sso@3.598.0(@aws-sdk/client-sso-oidc@3.600.0)':
     dependencies:
       '@aws-sdk/client-sso': 3.598.0
-      '@aws-sdk/token-providers': 3.598.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))
+      '@aws-sdk/token-providers': 3.598.0(@aws-sdk/client-sso-oidc@3.600.0)
       '@aws-sdk/types': 3.598.0
       '@smithy/property-provider': 3.1.2
       '@smithy/shared-ini-file-loader': 3.1.2
@@ -7034,9 +7037,9 @@ snapshots:
       - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
-  '@aws-sdk/credential-provider-web-identity@3.598.0(@aws-sdk/client-sts@3.600.0)':
+  '@aws-sdk/credential-provider-web-identity@3.598.0(@aws-sdk/client-sts@3.600.0(@aws-sdk/client-sso-oidc@3.600.0))':
     dependencies:
-      '@aws-sdk/client-sts': 3.600.0
+      '@aws-sdk/client-sts': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)
       '@aws-sdk/types': 3.598.0
       '@smithy/property-provider': 3.1.2
       '@smithy/types': 3.2.0
@@ -7161,9 +7164,9 @@ snapshots:
       '@smithy/types': 3.2.0
       tslib: 2.6.3
 
-  '@aws-sdk/token-providers@3.598.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))':
+  '@aws-sdk/token-providers@3.598.0(@aws-sdk/client-sso-oidc@3.600.0)':
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.600.0(@aws-sdk/client-sts@3.600.0)
+      '@aws-sdk/client-sso-oidc': 3.600.0
       '@aws-sdk/types': 3.598.0
       '@smithy/property-provider': 3.1.2
       '@smithy/shared-ini-file-loader': 3.1.2


### PR DESCRIPTION
## What does this PR do?

Web app env is now typesafe and we dont need to define `NEXT_PUBLIC_` prefixed env anymore. We can expose selected env variables.

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Tested my code in a local environment
- [ ] Commented on my code in hard-to-understand areas
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the UnInbox Docs if changes were necessary
