### PR TITLE
feat: improve middleware performance by using plain fetch calls

### DIFF
--- a/apps/platform/routes/auth.ts
+++ b/apps/platform/routes/auth.ts
@@ -2,6 +2,9 @@ import { Hono } from 'hono';
 import type { Ctx } from '~platform/ctx';
 import { lucia } from '~platform/utils/auth';
 import { setCookie } from 'hono/cookie';
+import { db } from '@u22n/database';
+import { accounts } from '@u22n/database/schema';
+import { eq } from '@u22n/database/orm';
 
 export const authApi = new Hono<Ctx>();
 
@@ -11,6 +14,40 @@ authApi.get('/status', async (c) => {
     return c.json({ authStatus: 'unauthenticated' });
   }
   return c.json({ authStatus: 'authenticated' });
+});
+
+authApi.get('/redirection', async (c) => {
+  const account = c.get('account');
+  if (!account) {
+    return c.json({ defaultOrgShortCode: null }, 401);
+  }
+
+  const accountId = account.id;
+  const accountResponse = await db.query.accounts.findFirst({
+    where: eq(accounts.id, accountId),
+    columns: {},
+    with: {
+      orgMemberships: {
+        columns: {},
+        with: {
+          org: {
+            columns: {
+              shortcode: true
+            }
+          }
+        }
+      }
+    }
+  });
+
+  if (!accountResponse) {
+    return c.json({ error: 'User not found' }, 403);
+  }
+
+  return c.json({
+    defaultOrgShortCode:
+      accountResponse?.orgMemberships[0]?.org?.shortcode || null
+  });
 });
 
 authApi.post('/logout', async (c) => {

--- a/apps/web/src/app/[orgShortCode]/convo/[convoId]/_components/convo-views.tsx
+++ b/apps/web/src/app/[orgShortCode]/convo/[convoId]/_components/convo-views.tsx
@@ -1,18 +1,17 @@
-'use client';
-
 import { api } from '@/src/lib/trpc';
 import Link from 'next/link';
 import { type TypeId } from '@u22n/utils/typeid';
 import { useGlobalStore } from '@/src/providers/global-store-provider';
 import { useMemo } from 'react';
-import { formatParticipantData } from '../utils';
-import { MessagesPanel } from './_components/messages-panel';
-import TopBar from './_components/top-bar';
-import { ReplyBox } from './_components/reply-box';
+import { formatParticipantData } from '../../utils';
+import { MessagesPanel } from './messages-panel';
+import TopBar from './top-bar';
+import { ReplyBox } from './reply-box';
 import { Button } from '@/src/components/shadcn-ui/button';
 import { env } from '@/src/env';
+import { usePageTitle } from '@/src/hooks/use-page-title';
 
-export default function ConvoView({ convoId }: { convoId: TypeId<'convos'> }) {
+export function ConvoView({ convoId }: { convoId: TypeId<'convos'> }) {
   const orgShortCode = useGlobalStore((state) => state.currentOrg.shortCode);
   const {
     data: convoData,
@@ -22,6 +21,8 @@ export default function ConvoView({ convoId }: { convoId: TypeId<'convos'> }) {
     orgShortCode,
     convoPublicId: convoId
   });
+
+  usePageTitle(convoData?.data.subjects[0]?.subject ?? 'UnInbox');
 
   const attachments = useMemo(() => {
     if (!convoData) return [];
@@ -94,6 +95,8 @@ export default function ConvoView({ convoId }: { convoId: TypeId<'convos'> }) {
 
 export function ConvoNotFound() {
   const orgShortCode = useGlobalStore((state) => state.currentOrg.shortCode);
+  usePageTitle('Convo Not Found');
+
   return (
     <div className="flex h-full w-full flex-col items-center justify-center">
       <div>

--- a/apps/web/src/app/[orgShortCode]/convo/[convoId]/page.tsx
+++ b/apps/web/src/app/[orgShortCode]/convo/[convoId]/page.tsx
@@ -1,43 +1,14 @@
+'use client';
 import { validateTypeId } from '@u22n/utils/typeid';
-import ConvoView, { ConvoNotFound } from './page-client';
-import type { Metadata } from 'next';
-import { serverApi } from '@/src/lib/trpc.server';
+import { ConvoView, ConvoNotFound } from './_components/convo-views';
 
-interface ConvoPageParams {
-  orgShortCode: string;
-  convoId: string;
-}
-
-export async function generateMetadata({
+export default function ConvoPage({
   params
 }: {
-  params: ConvoPageParams;
-}): Promise<Metadata> {
-  const currentConvo = await serverApi.convos.getConvo.query({
-    orgShortCode: params.orgShortCode,
-    convoPublicId: params.convoId
-  });
-
-  if (!currentConvo) {
-    return {
-      title: 'Convo not found',
-      description: 'Convo not found',
-      icons: '/logo.png'
-    };
-  }
-
-  const title = currentConvo.data.subjects[0]
-    ? currentConvo.data.subjects[0]?.subject
-    : 'UnInbox';
-
-  return {
-    title: `Convo | ${title}`,
-    description: 'View and reply to this conversation',
-    icons: '/logo.png'
+  params: {
+    convoId: string;
   };
-}
-
-export default function ConvoPage({ params }: { params: ConvoPageParams }) {
+}) {
   if (!validateTypeId('convos', params.convoId)) {
     return <ConvoNotFound />;
   }

--- a/apps/web/src/hooks/use-page-title.tsx
+++ b/apps/web/src/hooks/use-page-title.tsx
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+
+export function usePageTitle(title?: string) {
+  useEffect(() => {
+    if (typeof window === 'undefined' || !title) return;
+    const prevTitle = document.title;
+    document.title = title;
+    return () => {
+      document.title = prevTitle;
+    };
+  }, [title]);
+}

--- a/apps/web/src/lib/middleware-utils.ts
+++ b/apps/web/src/lib/middleware-utils.ts
@@ -1,25 +1,19 @@
 import 'server-only';
-import type { TrpcPlatformRouter } from '@u22n/platform/trpc';
-import { createTRPCClient, httpBatchLink } from '@trpc/client';
-import SuperJSON from 'superjson';
 import { cookies, headers as nextHeaders } from 'next/headers';
-
-export const serverApi = createTRPCClient<TrpcPlatformRouter>({
-  links: [
-    httpBatchLink({
-      url: getBaseUrl() + '/trpc',
-      transformer: SuperJSON,
-      headers: async () => nextHeaders(),
-      fetch: (input, init) =>
-        fetch(input, { ...init, credentials: 'include', cache: 'no-store' })
-    })
-  ]
-});
 
 function getBaseUrl() {
   if (process.env.NEXT_PUBLIC_PLATFORM_URL)
     return process.env.NEXT_PUBLIC_PLATFORM_URL;
   throw new Error('NEXT_PUBLIC_PLATFORM_URL is not set');
+}
+
+export async function getAuthRedirection() {
+  if (!cookies().has('unsession')) return { defaultOrgShortCode: null };
+  return fetch(`${getBaseUrl()}/auth/redirection`, {
+    headers: nextHeaders()
+  }).then((r) => (r.ok ? r.json() : { defaultOrgShortCode: null })) as Promise<{
+    defaultOrgShortCode: string | null;
+  }>;
 }
 
 // Skip the cookie validation on client with shallow=true

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,4 +1,7 @@
-import { isAuthenticated, serverApi } from '@/src/lib/trpc.server';
+import {
+  isAuthenticated,
+  getAuthRedirection
+} from '@/src/lib/middleware-utils';
 import { type NextRequest, NextResponse } from 'next/server';
 
 // Known public routes, add more as needed
@@ -14,9 +17,7 @@ export default async function middleware(req: NextRequest) {
   // Redirect if already logged in on login page
   if (path === '/') {
     if (await isAuthenticated()) {
-      const redirectData = await serverApi.account.defaults.redirectionData
-        .query({})
-        .catch(() => null);
+      const redirectData = await getAuthRedirection().catch(() => null);
       if (redirectData) {
         return NextResponse.redirect(
           new URL(redirectData.defaultOrgShortCode ?? '/join/org', req.nextUrl)


### PR DESCRIPTION
## What does this PR do?
Removed the server side trpc api and changed the redirect call to a plain fetch call to make the middleware function small, efficient and reliable.

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Tested my code in a local environment
- [ ] Commented on my code in hard-to-understand areas
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the UnInbox Docs if changes were necessary
