### PR TITLE
fix: username validation regex

### DIFF
--- a/apps/platform/trpc/routers/authRouter/passwordRouter.ts
+++ b/apps/platform/trpc/routers/authRouter/passwordRouter.ts
@@ -168,7 +168,7 @@ export const passwordRouter = router({
     .use(ratelimiter({ limit: 20, namespace: 'signIn.password' }))
     .input(
       z.object({
-        username: zodSchemas.username(2),
+        username: zodSchemas.usernameLogin(2),
         password: z.string().min(8)
       })
     )

--- a/apps/platform/trpc/routers/authRouter/recoveryRouter.ts
+++ b/apps/platform/trpc/routers/authRouter/recoveryRouter.ts
@@ -27,7 +27,7 @@ export const recoveryRouter = router({
     .input(
       z
         .object({
-          username: zodSchemas.username(2),
+          username: zodSchemas.usernameLogin(2),
           recoveryCode: zodSchemas.nanoIdToken()
         })
         .and(

--- a/apps/platform/trpc/routers/orgRouter/mail/emailIdentityRouter.ts
+++ b/apps/platform/trpc/routers/orgRouter/mail/emailIdentityRouter.ts
@@ -32,7 +32,13 @@ export const emailIdentityRouter = router({
   checkEmailAvailability: orgProcedure
     .input(
       z.object({
-        emailUsername: z.string().min(1).max(255),
+        emailUsername: z
+          .string()
+          .min(1)
+          .max(255)
+          .regex(/^[a-zA-Z0-9._-]*$/, {
+            message: 'Only letters, numbers, dots, hyphens and underscores'
+          }),
         domainPublicId: typeIdValidator('domains')
       })
     )
@@ -89,7 +95,13 @@ export const emailIdentityRouter = router({
   createNewEmailIdentity: orgAdminProcedure
     .input(
       z.object({
-        emailUsername: z.string().min(1).max(255),
+        emailUsername: z
+          .string()
+          .min(1)
+          .max(255)
+          .regex(/^[a-zA-Z0-9._-]*$/, {
+            message: 'Only letters, numbers, dots, hyphens and underscores'
+          }),
         domainPublicId: typeIdValidator('domains'),
         sendName: z.string().min(2).max(255),
         catchAll: z.boolean().optional().default(false),

--- a/packages/utils/zodSchemas.ts
+++ b/packages/utils/zodSchemas.ts
@@ -40,7 +40,19 @@ export const zodSchemas = {
         message: `Must be at least ${minLength} characters long`
       })
       .max(32, {
-        message: "Too Long, Ain't nobody typing that 😂"
+        message: 'Too Long'
+      })
+      .regex(/^[a-zA-Z0-9]*$/, {
+        message: 'Only letters and numbers'
+      }),
+  usernameLogin: (minLength: number = 5) =>
+    z
+      .string()
+      .min(minLength, {
+        message: `Must be at least ${minLength} characters long`
+      })
+      .max(32, {
+        message: 'Too Long'
       })
       .regex(/^[a-zA-Z0-9._-]*$/, {
         message: 'Only letters and numbers'


### PR DESCRIPTION
Sets username validation to only allow letters and numbers
removed previously added `. - _` due to issues

it allows login with those characters since we have 200 users with those characters in their names

---

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

_If there is not an issue for this, please create one first. This is used to tracking purposes and also helps use understand why this PR exists_

<!-- If there isn't an issue for this PR, please re-review our Contributing Guide and create an issue -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Tested my code in a local environment
- [ ] Commented on my code in hard-to-understand areas
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the UnInbox Docs if changes were necessary
