### PR TITLE
fix: email identity claim modal button sizes

### DIFF
--- a/apps/web/src/app/[orgShortcode]/_components/claim-email-identity.tsx
+++ b/apps/web/src/app/[orgShortcode]/_components/claim-email-identity.tsx
@@ -31,12 +31,18 @@ export function ClaimEmailIdentity() {
             You can also ask your Organization admin to assign a email to you
           </p>
         </div>
-        <DialogFooter>
+        <DialogFooter className="flex gap-2">
           <DialogClose asChild>
-            <Button variant="secondary">Ignore for now</Button>
+            <Button
+              variant="secondary"
+              className="flex-1">
+              Ignore for now
+            </Button>
           </DialogClose>
           <DialogClose asChild>
-            <Button asChild>
+            <Button
+              asChild
+              className="flex-1">
               <Link href={`/${orgShortcode}/settings/user/addresses`}>
                 Claim Free @uninbox.me Address
               </Link>


### PR DESCRIPTION
## What does this PR do?

Fix the sizing of buttons in Email Claim modal

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/pdcPzzwHY7gqQNDOL86j/cc406ce0-2ed4-4a90-ba4c-80ff5620b922.png)


## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Tested my code in a local environment
- [ ] Commented on my code in hard-to-understand areas
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the UnInbox Docs if changes were necessary
