### PR TITLE
chore: improve app layout with auto reties and manual retry buttons

### DIFF
--- a/apps/web/src/app/[orgShortcode]/layout.tsx
+++ b/apps/web/src/app/[orgShortcode]/layout.tsx
@@ -2,7 +2,7 @@
 
 import Sidebar from './_components/sidebar';
 import { GlobalStoreProvider } from '@/src/providers/global-store-provider';
-import { buttonVariants } from '@/src/components/shadcn-ui/button';
+import { Button } from '@/src/components/shadcn-ui/button';
 import { SpinnerGap } from '@phosphor-icons/react';
 import Link from 'next/link';
 import { platform } from '@/src/lib/trpc';
@@ -18,7 +18,10 @@ export default function Layout({
     data: storeData,
     isLoading: storeDataLoading,
     error: storeError
-  } = platform.org.store.getStoreData.useQuery({ orgShortcode });
+  } = platform.org.store.getStoreData.useQuery(
+    { orgShortcode },
+    { retry: 3, retryDelay: (attemptIndex) => attemptIndex * 5000 }
+  );
 
   const { data: hasEmailIdentity } =
     platform.org.mail.emailIdentities.userHasEmailIdentities.useQuery({
@@ -29,28 +32,39 @@ export default function Layout({
     return (
       <div className="flex h-full w-full flex-col items-center justify-center gap-2">
         <SpinnerGap className="text-base-11 h-20 w-20 animate-spin" />
+        <span className="text-slate-11 font-bold">
+          <span className="font-display text-slate-12 text-bold">UnInbox</span>{' '}
+          is Loading...
+        </span>
       </div>
     );
   }
 
-  if (storeError && !storeDataLoading) {
+  if (storeError) {
     return (
       <div className="flex h-full w-full flex-col items-center justify-center gap-2">
         <h1 className="text-red-11 text-2xl font-bold">An Error Occurred!</h1>
         <span className="text-red-11 whitespace-pre font-mono text-xl">
           {storeError.message}
         </span>
-
-        <Link
-          className={buttonVariants({ variant: 'outline' })}
-          href="/">
-          Go Back Home
-        </Link>
+        <div className="flex gap-2">
+          <Button
+            variant="outline"
+            className="flex-1"
+            asChild>
+            <Link href="/">Go Back</Link>
+          </Button>
+          <Button
+            className="flex-1"
+            onClick={() => window.location.reload()}>
+            Retry
+          </Button>
+        </div>
       </div>
     );
   }
 
-  if (!storeDataLoading && !storeData?.currentOrg) {
+  if (!storeData?.currentOrg) {
     return (
       <div className="flex h-full w-full flex-col items-center justify-center gap-2">
         <h1 className="text-red-11 text-2xl font-bold">Invalid Org</h1>
@@ -61,32 +75,30 @@ export default function Layout({
           does not exists or you are not part of that org!
         </span>
 
-        <Link
-          className={buttonVariants({ variant: 'outline' })}
-          href="/">
-          Go Back Home
-        </Link>
+        <Button
+          variant="outline"
+          className="flex-1"
+          asChild>
+          <Link href="/">Go Back</Link>
+        </Button>
       </div>
     );
   }
 
-  if (storeData) {
-    return (
-      <GlobalStoreProvider initialState={storeData}>
-        <div className="bg-base-1 max-w-svh flex h-full max-h-svh w-full flex-row gap-0 overflow-hidden p-0">
-          <div className="h-full max-h-full w-fit">
-            <Sidebar />
-          </div>
-          <div className="flex h-full w-full flex-row p-0">
-            <RealtimeProvider>{children}</RealtimeProvider>
-          </div>
-
-          <NewConvoSheet />
-          {hasEmailIdentity && !hasEmailIdentity.hasIdentity && (
-            <ClaimEmailIdentity />
-          )}
+  return (
+    <GlobalStoreProvider initialState={storeData}>
+      <div className="bg-base-1 max-w-svh flex h-full max-h-svh w-full flex-row gap-0 overflow-hidden p-0">
+        <div className="h-full max-h-full w-fit">
+          <Sidebar />
         </div>
-      </GlobalStoreProvider>
-    );
-  }
+        <div className="flex h-full w-full flex-row p-0">
+          <RealtimeProvider>{children}</RealtimeProvider>
+        </div>
+        <NewConvoSheet />
+        {hasEmailIdentity && !hasEmailIdentity.hasIdentity && (
+          <ClaimEmailIdentity />
+        )}
+      </div>
+    </GlobalStoreProvider>
+  );
 }


### PR DESCRIPTION
## What does this PR do?

The app will now automatically retry if the org layout fails to load and will give users a button to reload the page

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Tested my code in a local environment
- [ ] Commented on my code in hard-to-understand areas
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the UnInbox Docs if changes were necessary
