### PR TITLE
fix: realtime client opening 2 connections

### DIFF
--- a/apps/web/src/providers/realtime-provider.tsx
+++ b/apps/web/src/providers/realtime-provider.tsx
@@ -32,7 +32,7 @@ export function RealtimeProvider({ children }: PropsWithChildren) {
       );
     });
     return () => {
-      client.disconnect();
+      if (client.isConnected) client.disconnect();
     };
   }, [client, orgShortcode]);
 

--- a/packages/realtime/client.ts
+++ b/packages/realtime/client.ts
@@ -121,7 +121,7 @@ export default class RealtimeClient {
   }
 
   public get isConnected() {
-    return !!this.client;
+    return !!this.client && this.client.connection.state === 'connected';
   }
 
   private bindEvents() {


### PR DESCRIPTION
## What does this PR do?

Realtime client tries to open 2 web socket connection everytime. This PR fixes that by not disconnecting the older one if its not yet connected so a second one doesn't occur

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Tested my code in a local environment
- [ ] Commented on my code in hard-to-understand areas
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the UnInbox Docs if changes were necessary
