### PR TITLE
feat: ability to send a message to support

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -59,7 +59,7 @@
     "next-client-cookies": "^1.1.1",
     "next-runtime-env": "^3.2.2",
     "next-themes": "^0.3.0",
-    "nuqs": "^1.17.4",
+    "nuqs": "^1.17.6",
     "postcss-import": "^16.1.0",
     "posthog-js": "^1.154.1",
     "qrcode.react": "^3.1.0",

--- a/apps/web/src/app/[orgShortcode]/_components/sidebar-content.tsx
+++ b/apps/web/src/app/[orgShortcode]/_components/sidebar-content.tsx
@@ -336,13 +336,18 @@ function OrgMenu() {
                     </div>
                   </DropdownMenuItem>
                   <DropdownMenuItem>
-                    <div
-                      className={
-                        'text-base-11 flex w-full flex-row items-center gap-2 font-medium'
-                      }>
-                      <QuestionMark />
-                      <span>Support</span>
-                    </div>
+                    <Link
+                      href={`${env.NEXT_PUBLIC_WEBAPP_URL}/${currentOrg.shortcode}/convo/new?emails=support@uninbox.com`}
+                      target="_blank">
+                      <div
+                        className={
+                          'text-base-11 flex w-full flex-row items-center gap-2 font-medium'
+                        }>
+                        <QuestionMark />
+
+                        <span>Support</span>
+                      </div>
+                    </Link>
                   </DropdownMenuItem>
                   <DropdownMenuItem>
                     <div

--- a/apps/web/src/app/[orgShortcode]/_components/sidebar-content.tsx
+++ b/apps/web/src/app/[orgShortcode]/_components/sidebar-content.tsx
@@ -337,7 +337,7 @@ function OrgMenu() {
                   </DropdownMenuItem>
                   <DropdownMenuItem>
                     <Link
-                      href={`${env.NEXT_PUBLIC_WEBAPP_URL}/${currentOrg.shortcode}/convo/new?emails=support@uninbox.com`}
+                      href={`${env.NEXT_PUBLIC_WEBAPP_URL}/${currentOrg.shortcode}/convo/new?emails=support@uninbox.com&subject=Need%20help%20getting%20unblocked`}
                       target="_blank">
                       <div
                         className={

--- a/apps/web/src/app/[orgShortcode]/convo/_components/create-convo-form.tsx
+++ b/apps/web/src/app/[orgShortcode]/convo/_components/create-convo-form.tsx
@@ -107,9 +107,11 @@ const selectedParticipantsAtom = atom<NewConvoParticipant[]>([]);
 const newEmailParticipantsAtom = atom<string[]>([]);
 
 export default function CreateConvoForm({
-  initialEmails = []
+  initialEmails = [],
+  initialSubject = ''
 }: {
   initialEmails?: string[];
+  initialSubject?: string;
 }) {
   const orgShortcode = useGlobalStore((state) => state.currentOrg.shortcode);
 
@@ -149,7 +151,7 @@ export default function CreateConvoForm({
   const [selectedEmailIdentity, setSelectedEmailIdentity] = useState<
     string | null
   >(null);
-  const [topic, setTopic] = useState('');
+  const [topic, setTopic] = useState(initialSubject);
   const { attachments, openFilePicker, getTrpcUploadFormat, AttachmentArray } =
     useAttachmentUploader();
 
@@ -406,35 +408,43 @@ export default function CreateConvoForm({
   const setNewEmailParticipants = useSetAtom(newEmailParticipantsAtom);
   const setSelectedParticipants = useSetAtom(selectedParticipantsAtom);
 
-  const initializeEmailParticipants = (emails: string[]) => {
-    const uniqueEmails = [...new Set(emails)];
-    setNewEmailParticipants(uniqueEmails);
-    setSelectedParticipants((prev) => {
-      const newParticipants = uniqueEmails.map((email) => ({
-        type: 'email' as const,
-        publicId: email,
-        address: email,
-        keywords: [email],
-        avatarPublicId: null,
-        avatarTimestamp: null,
-        color: null,
-        own: false,
-        name: email
-      }));
-      return [
-        ...prev,
-        ...newParticipants.filter(
-          (p) => !prev.some((existing) => existing.publicId === p.publicId)
-        )
-      ];
-    });
-  };
-
   useEffect(() => {
+    const initializeEmailParticipants = (emails: string[]) => {
+      const uniqueEmails = [...new Set(emails)];
+      setNewEmailParticipants(uniqueEmails);
+      setSelectedParticipants((prev) => {
+        const newParticipants = uniqueEmails.map((email) => ({
+          type: 'email' as const,
+          publicId: email,
+          address: email,
+          keywords: [email],
+          avatarPublicId: null,
+          avatarTimestamp: null,
+          color: null,
+          own: false,
+          name: email
+        }));
+        return [
+          ...prev,
+          ...newParticipants.filter(
+            (p) => !prev.some((existing) => existing.publicId === p.publicId)
+          )
+        ];
+      });
+    };
     if (initialEmails.length > 0) {
       initializeEmailParticipants(initialEmails);
     }
-  }, [initialEmails]);
+    if (initialSubject) {
+      setTopic(initialSubject);
+    }
+  }, [
+    initialEmails,
+    initialSubject,
+    setTopic,
+    setNewEmailParticipants,
+    setSelectedParticipants
+  ]);
 
   return (
     <div className="flex w-full flex-col gap-3 p-3">

--- a/apps/web/src/app/[orgShortcode]/convo/new/page.tsx
+++ b/apps/web/src/app/[orgShortcode]/convo/new/page.tsx
@@ -1,6 +1,9 @@
 'use client';
 import CreateConvoForm from '../_components/create-convo-form';
+import { useQueryState } from 'nuqs';
 
 export default function Page() {
-  return <CreateConvoForm />;
+  const [emails] = useQueryState('emails', { parse: (v) => v?.split(',') });
+
+  return <CreateConvoForm initialEmails={emails ?? []} />;
 }

--- a/apps/web/src/app/[orgShortcode]/convo/new/page.tsx
+++ b/apps/web/src/app/[orgShortcode]/convo/new/page.tsx
@@ -4,6 +4,12 @@ import { useQueryState } from 'nuqs';
 
 export default function Page() {
   const [emails] = useQueryState('emails', { parse: (v) => v?.split(',') });
+  const [subject] = useQueryState('subject');
 
-  return <CreateConvoForm initialEmails={emails ?? []} />;
+  return (
+    <CreateConvoForm
+      initialEmails={emails ?? []}
+      initialSubject={subject ?? ''}
+    />
+  );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -429,7 +429,7 @@ importers:
         specifier: ^0.3.0
         version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       nuqs:
-        specifier: ^1.17.4
+        specifier: ^1.17.6
         version: 1.17.6(next@14.2.5(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       postcss-import:
         specifier: ^16.1.0


### PR DESCRIPTION
## What does this PR do?
This PR adds support for pre-filling email recipients and subject when creating a new conversation via URL parameters. It also updates the "Support" link in the sidebar to open a new conversation with the support email pre-filled.

## Type of change
- [x] Enhancement (small improvements)

## Checklist
- [x] Self-reviewed my own code
- [x] Tested my code in a local environment
- [x] My changes don't cause any responsiveness issues

## Changes
- Updated `CreateConvoForm` component to accept `initialEmails` and `initialSubject` props
- Modified the new conversation page to parse `emails` and `subject` query parameters
- Updated the "Support" link in the sidebar to include pre-filled email and subject
- Minor package updates (nuqs)

## Testing
1. Click the "Support" link in the sidebar and verify it opens a new conversation with support@uninbox.com pre-filled
2. Test creating a new conversation with custom email and subject via URL: 
   `/[orgShortcode]/convo/new?emails=test@example.com&subject=Test Subject`

https://github.com/user-attachments/assets/d351407b-1934-4b47-87b7-dd30f3d3357c


