### PR TITLE
fix: bugs I found in redeem invite logic

### DIFF
--- a/ee/apps/billing/routes/stripe.ts
+++ b/ee/apps/billing/routes/stripe.ts
@@ -18,8 +18,8 @@ stripeApi.post('/webhooks', async (c) => {
     console.info('Unhandled stripe event', {
       event: stripeEvent.type
     });
-    return c.json(null, 200);
   }
+  return c.json(null, 200);
 });
 
 const handleCustomerSubscriptionUpdated = async (stripeEvent: Stripe.Event) => {

--- a/ee/apps/billing/trpc/routers/subscriptionsRouter.ts
+++ b/ee/apps/billing/trpc/routers/subscriptionsRouter.ts
@@ -26,18 +26,19 @@ export const subscriptionsRouter = router({
           period: true
         }
       });
+
       if (!orgSubscriptionQuery?.id) {
         return { error: 'Org is not subscribed to a plan' };
       }
 
       const activeOrgMembersCount = await db
-        .select({ count: sql<number>`count(*)` })
+        .select({ count: sql<string>`count(*)` })
         .from(orgMembers)
         .where(
           and(eq(orgMembers.orgId, orgId), eq(orgMembers.status, 'active'))
         );
 
-      const totalOrgUsers = activeOrgMembersCount[0]?.count ?? 1;
+      const totalOrgUsers = Number(activeOrgMembersCount[0]?.count ?? '1');
 
       if (orgSubscriptionQuery.stripeSubscriptionId) {
         const stripeGetSubscriptionResult =


### PR DESCRIPTION
## What does this PR do?

I found a few bugs in the redeemInvite logic while investigating the issue with stripe billing, this PR fixes this.

- Type of `totalOrgMember` was string, casted to number
- Always return a response from stripe webhook endpoint
- Throw error if user tries to join same org again


## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Tested my code in a local environment
- [ ] Commented on my code in hard-to-understand areas
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the UnInbox Docs if changes were necessary
