### PR TITLE
chore: make every settings page consistently full width

### DIFF
--- a/apps/web/src/app/[orgShortcode]/settings/org/users/invites/_components/columns.tsx
+++ b/apps/web/src/app/[orgShortcode]/settings/org/users/invites/_components/columns.tsx
@@ -1,20 +1,10 @@
 'use client';
 
-import {
-  Tooltip,
-  TooltipTrigger,
-  TooltipContent
-} from '@/src/components/shadcn-ui/tooltip';
-import {
-  Avatar,
-  AvatarFallback,
-  AvatarImage
-} from '@/src/components/shadcn-ui/avatar';
 import { createColumnHelper, type ColumnDef } from '@tanstack/react-table';
-import { generateAvatarUrl, getInitials } from '@/src/lib/utils';
 import { CopyButton } from '@/src/components/copy-button';
 import { Badge } from '@/src/components/shadcn-ui/badge';
 import type { RouterOutputs } from '@/src/lib/trpc';
+import { Avatar } from '@/src/components/avatar';
 import { format } from 'date-fns';
 import { env } from '@/src/env';
 
@@ -42,27 +32,14 @@ export const columns: ColumnDef<Member>[] = [
       const { publicId, avatarTimestamp, firstName, lastName } =
         row.original.orgMember?.profile ?? {};
 
-      const avatarUrl =
-        avatarTimestamp && publicId
-          ? generateAvatarUrl({
-              avatarTimestamp,
-              publicId,
-              size: 'lg'
-            })
-          : null;
-      const initials = getInitials(`${firstName} ${lastName}`);
       return (
         <div className="flex items-center gap-2">
-          <Avatar className="h-8 w-8">
-            <AvatarImage
-              src={avatarUrl ?? undefined}
-              alt={firstName ?? ''}
-            />
-            <AvatarFallback>{initials}</AvatarFallback>
-          </Avatar>
-          <span>
-            {firstName} {lastName}
-          </span>
+          <Avatar
+            avatarProfilePublicId={publicId ?? 'no_avatar'}
+            avatarTimestamp={avatarTimestamp ?? null}
+            name={`${firstName ?? ''} ${lastName ?? ''}`}
+          />
+          <span className="whitespace-nowrap text-xs">{`${firstName} ${lastName}`}</span>
         </div>
       );
     }
@@ -130,30 +107,13 @@ export const columns: ColumnDef<Member>[] = [
     cell: ({ row }) => {
       const { publicId, avatarTimestamp, firstName, lastName } =
         row.original.invitedByOrgMember.profile;
-
-      const avatarUrl =
-        avatarTimestamp && publicId
-          ? generateAvatarUrl({
-              avatarTimestamp,
-              publicId,
-              size: 'lg'
-            })
-          : null;
-      const initials = getInitials(`${firstName} ${lastName}`);
       return (
         <div className="flex items-center justify-center gap-2">
-          <Tooltip>
-            <TooltipTrigger>
-              <Avatar className="h-8 w-8">
-                <AvatarImage
-                  src={avatarUrl ?? undefined}
-                  alt={firstName ?? ''}
-                />
-                <AvatarFallback>{initials}</AvatarFallback>
-              </Avatar>
-            </TooltipTrigger>
-            <TooltipContent>{`${firstName} ${lastName}`}</TooltipContent>
-          </Tooltip>
+          <Avatar
+            avatarProfilePublicId={publicId ?? 'no_avatar'}
+            avatarTimestamp={avatarTimestamp ?? null}
+            name={`${firstName ?? ''} ${lastName ?? ''}`}
+          />
         </div>
       );
     }
@@ -164,7 +124,7 @@ export const columns: ColumnDef<Member>[] = [
     cell: ({ row }) => {
       const expiry = row.original.expiresAt;
       return expiry ? (
-        <div className="flex h-full items-center">
+        <div className="flex h-full items-center whitespace-nowrap">
           {format(expiry, 'eee, do MMM yyyy')}
         </div>
       ) : null;

--- a/apps/web/src/app/[orgShortcode]/settings/org/users/invites/page.tsx
+++ b/apps/web/src/app/[orgShortcode]/settings/org/users/invites/page.tsx
@@ -16,7 +16,7 @@ export default function Page() {
     });
 
   return (
-    <div className="flex flex-col gap-2 p-4">
+    <div className="flex w-full flex-col gap-2 p-4">
       <PageTitle
         title="Invites"
         description="Grow your Org with Invitations">

--- a/apps/web/src/app/[orgShortcode]/settings/user/addresses/page.tsx
+++ b/apps/web/src/app/[orgShortcode]/settings/user/addresses/page.tsx
@@ -29,7 +29,7 @@ export default function Page() {
   } = platform.account.addresses.getPersonalAddresses.useQuery();
 
   return (
-    <div className="flex flex-col gap-4 p-4">
+    <div className="flex w-full flex-col gap-4 p-4">
       <PageTitle title="Your Addresses" />
 
       {personalAddressesLoading && <Skeleton className="h-10 w-full" />}


### PR DESCRIPTION
## What does this PR do?

Some settings page were not consistently full width, specially invites table looked awful.
This PR makes every settings page follow same general layout

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Tested my code in a local environment
- [ ] Commented on my code in hard-to-understand areas
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the UnInbox Docs if changes were necessary
