### PR TITLE
fix: remove `&shy;` tags from message content

### DIFF
--- a/apps/web/src/app/[orgShortcode]/convo/[convoId]/_components/messages-panel.tsx
+++ b/apps/web/src/app/[orgShortcode]/convo/[convoId]/_components/messages-panel.tsx
@@ -387,7 +387,13 @@ const emptyMessage = `<span class="text-base-11 text-sm">THIS MESSAGE CONTAINS N
 
 // Doing the Fixes Client Side so that we can revert them later if needed
 const clientSideHtmlFixes = (html: string) =>
-  html.replaceAll('&nbsp;', ' ').replaceAll('&#160;', ' ').trim();
+  html
+    .replaceAll('&nbsp;', ' ')
+    .replaceAll('&#160;', ' ')
+    .replaceAll('&shy;', ' ')
+    .replaceAll('&#173;', ' ')
+    .replaceAll(/\u00AD/, ' ')
+    .trim();
 
 // It is important to memoize the HTMLMessage component to prevent unnecessary re-renders which can cause infinite fetch loops for images
 const HTMLMessage = memo(


### PR DESCRIPTION
## What does this PR do?

Remove `&shy;` in client side html

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Tested my code in a local environment
- [ ] Commented on my code in hard-to-understand areas
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the UnInbox Docs if changes were necessary
