### PR TITLE
feat: Improvements to convo and reply box

### DIFF
--- a/apps/web/src/app/[orgShortcode]/convo/[convoId]/_components/reply-box.tsx
+++ b/apps/web/src/app/[orgShortcode]/convo/[convoId]/_components/reply-box.tsx
@@ -71,10 +71,10 @@ export function ReplyBox({
   const { mutateAsync: replyToConvo, isPending: replyToConvoLoading } =
     platform.convos.replyToConvo.useMutation({
       onSuccess: () => {
+        resetDraft();
         editorRef.current?.clearContent();
         setEditorText(emptyTiptapEditorContent);
         removeAllAttachments();
-        resetDraft();
       }
     });
 
@@ -195,7 +195,25 @@ export function ReplyBox({
 
   return (
     <div className="flex min-h-32 flex-col p-4">
-      <div className="border-base-5 flex max-h-[250px] w-full flex-col gap-1 rounded-md border p-1">
+      <div
+        className={cn(
+          'border-base-5 group relative mt-3 flex max-h-[250px] w-full flex-col gap-1 rounded-md border px-2 py-1',
+          !isEditorEmpty && 'hover:rounded-tr-none'
+        )}>
+        {!isEditorEmpty && (
+          <Button
+            variant="link"
+            size="xs"
+            className="text-base-11 border-base-5 bg-base-1 absolute -top-5 right-[-1px] h-5 translate-y-4 cursor-pointer rounded-b-none border border-b-0 py-0 text-xs opacity-0 transition-all delay-100 group-hover:translate-y-0 group-hover:opacity-100"
+            onClick={() => {
+              resetDraft();
+              editorRef.current?.clearContent();
+              removeAllAttachments();
+              setEditorText(emptyTiptapEditorContent);
+            }}>
+            Clear Draft
+          </Button>
+        )}
         <Editor
           initialValue={editorText}
           onChange={setEditorText}

--- a/apps/web/src/app/[orgShortcode]/convo/_components/new-convo-sheet.tsx
+++ b/apps/web/src/app/[orgShortcode]/convo/_components/new-convo-sheet.tsx
@@ -9,13 +9,17 @@ import {
   DrawerTrigger
 } from '@/src/components/shadcn-ui/drawer';
 import { showNewConvoPanel } from '@/src/app/[orgShortcode]/convo/atoms';
+import { useGlobalStore } from '@/src/providers/global-store-provider';
+import { ArrowsOutSimple, Plus, X } from '@phosphor-icons/react';
 import { Button } from '@/src/components/shadcn-ui/button';
 import CreateConvoForm from './create-convo-form';
-import { Plus, X } from '@phosphor-icons/react';
+import { useRouter } from 'next/navigation';
 import { useAtom } from 'jotai';
 
 export function NewConvoSheet() {
   const [open, setOpen] = useAtom(showNewConvoPanel);
+  const orgShortcode = useGlobalStore((state) => state.currentOrg.shortcode);
+  const router = useRouter();
 
   return (
     <Drawer
@@ -43,12 +47,30 @@ export function NewConvoSheet() {
           </DrawerDescription>
         </DrawerHeader>
 
-        <Button
-          variant={'ghost'}
-          onClick={() => setOpen(false)}
-          className="fixed right-1 top-1">
-          <X className="h-4 w-4" />
-        </Button>
+        <div className="absolute right-1 top-1 flex gap-0 p-1">
+          <Button
+            size={'icon'}
+            variant={'ghost'}
+            onClick={() => {
+              router.push(`/${orgShortcode}/convo/new`);
+              setOpen(false);
+            }}>
+            <ArrowsOutSimple
+              className="size-4"
+              size={16}
+            />
+          </Button>
+          <Button
+            size={'icon'}
+            variant={'ghost'}
+            onClick={() => setOpen(false)}>
+            <X
+              className="size-4"
+              size={16}
+            />
+          </Button>
+        </div>
+
         <CreateConvoForm />
       </DrawerContent>
     </Drawer>

--- a/apps/web/src/components/shadcn-ui/input.tsx
+++ b/apps/web/src/components/shadcn-ui/input.tsx
@@ -34,7 +34,11 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
     const [hasValue, setHasValue] = React.useState(false);
 
     React.useEffect(() => {
-      props.value && setHasValue(true);
+      if (!props.value) {
+        setHasValue(false);
+      } else {
+        setHasValue(true);
+      }
     }, [props.value]);
 
     return (


### PR DESCRIPTION
## What does this PR do?

Various Improvements to convo and reply box
- There is a clear draft button now
- New Email participants now show up at front for easier un-selecting
- Email participants now loads correctly from draft
- New convo popup can be full screened now
- You can't select yourself as participant anymore, it was disabled but pressing it still added yourself

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Tested my code in a local environment
- [ ] Commented on my code in hard-to-understand areas
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the UnInbox Docs if changes were necessary
