### PR TITLE
feat: raw emails and inline images support

### DIFF
--- a/apps/mail-bridge/package.json
+++ b/apps/mail-bridge/package.json
@@ -33,6 +33,7 @@
     "mailauth": "^4.6.8",
     "mailparser": "^3.7.1",
     "mime": "^4.0.4",
+    "mimetext": "^3.0.24",
     "mysql2": "^3.10.1",
     "nanoid": "^5.0.7",
     "nodemailer": "^6.9.14",

--- a/apps/mail-bridge/queue/mail-processor.ts
+++ b/apps/mail-bridge/queue/mail-processor.ts
@@ -18,9 +18,9 @@ import {
   type TypeId
 } from '@u22n/utils/typeid';
 import { createQueue, createWorker } from '../utils/queue-helpers';
+import { createExtensionSet } from '@u22n/tiptap/extensions';
 import { sendRealtimeNotification } from '../utils/realtime';
 import { simpleParser, type EmailAddress } from 'mailparser';
-import { tipTapExtensions } from '@u22n/tiptap/extensions';
 import { parseAddressIds } from '../utils/contactParsing';
 import { eq, and, inArray } from '@u22n/database/orm';
 import { tiptapCore, tiptapHtml } from '@u22n/tiptap';
@@ -34,6 +34,8 @@ import { db } from '@u22n/database';
 import { env } from '../env';
 import mime from 'mime';
 import { z } from 'zod';
+
+const tipTapExtensions = createExtensionSet();
 
 async function resolveOrgAndMailserver({
   mailserverId,

--- a/apps/mail-bridge/smtp/sendEmail.ts
+++ b/apps/mail-bridge/smtp/sendEmail.ts
@@ -3,34 +3,14 @@ import type { AuthOptions } from './auth';
 
 export type SendEmailOptions = {
   to: string[];
-  cc: string[];
   from: string;
-  sender: string;
-  subject: string;
-  plainBody: string;
-  htmlBody: string;
-  attachments: {
-    name: string;
-    content_type: string;
-    data: string;
-    base64: boolean;
-  }[];
   headers: Record<string, string>;
+  raw: string;
 };
 
 export async function sendEmail({
   auth: { host, port, username, password, encryption, authMethod },
-  email: {
-    to,
-    cc,
-    from,
-    sender,
-    subject,
-    plainBody,
-    htmlBody,
-    attachments,
-    headers
-  }
+  email: { to, from, headers, raw }
 }: {
   auth: AuthOptions;
   email: SendEmailOptions;
@@ -46,24 +26,9 @@ export async function sendEmail({
     }
   });
   const res = await transport.sendMail({
-    envelope: {
-      to,
-      from
-    },
-    to,
-    cc,
-    from,
-    sender,
-    subject,
-    html: htmlBody,
-    text: plainBody,
-    attachments: attachments.map(({ name, content_type, data, base64 }) => ({
-      contentType: content_type,
-      filename: name,
-      content: data,
-      encoding: base64 ? 'base64' : 'utf8'
-    })),
-    headers
+    envelope: { to, from },
+    headers,
+    raw
   });
   return res;
 }

--- a/apps/mail-bridge/utils/tiptap-utils.ts
+++ b/apps/mail-bridge/utils/tiptap-utils.ts
@@ -1,0 +1,43 @@
+import type { JSONContent } from '@u22n/tiptap/react';
+import { validateTypeId } from '@u22n/utils/typeid';
+
+export function walkAndReplaceImages(
+  jsonContent: JSONContent,
+  callback: (url: string) => string
+) {
+  for (const element of jsonContent.content ?? []) {
+    if (element.type === 'image' && typeof element.attrs?.src === 'string') {
+      const newUrl = callback(element.attrs.src);
+      if (element.attrs) {
+        element.attrs.src = newUrl;
+      }
+    }
+    if (element.content) {
+      walkAndReplaceImages(element, callback);
+    }
+  }
+}
+
+export function tryParseInlineAttachmentUrl(url: string) {
+  try {
+    const urlObject = new URL(url);
+    const [base, orgShortcode, attachmentPublicId, fileName] =
+      urlObject.pathname.split('/').splice(1);
+
+    if (
+      base !== 'attachment' ||
+      !orgShortcode ||
+      !validateTypeId('convoAttachments', attachmentPublicId) ||
+      !fileName
+    )
+      return null;
+
+    return {
+      orgShortcode,
+      attachmentPublicId,
+      fileName
+    };
+  } catch (e) {
+    return null;
+  }
+}

--- a/apps/platform/ctx.ts
+++ b/apps/platform/ctx.ts
@@ -1,4 +1,5 @@
 import type { Context } from '@u22n/hono/helpers';
+import type { TypeId } from '@u22n/utils/typeid';
 import type { HonoContext } from '@u22n/hono';
 import type { DBType } from '@u22n/database';
 import type { DatabaseSession } from 'lucia';
@@ -9,7 +10,7 @@ export type Ctx = HonoContext<{
 
 export type OrgContext = {
   id: number;
-  publicId: string;
+  publicId: TypeId<'org'>;
   name: string;
   memberId?: number;
   members: {

--- a/apps/platform/utils/tiptap-utils.ts
+++ b/apps/platform/utils/tiptap-utils.ts
@@ -1,0 +1,49 @@
+import type { JSONContent } from '@u22n/tiptap/react';
+import { validateTypeId } from '@u22n/utils/typeid';
+
+export function walkAndReplaceImages(
+  jsonContent: JSONContent,
+  callback: (url: string) => string
+) {
+  for (const element of jsonContent.content ?? []) {
+    if (element.type === 'image' && typeof element.attrs?.src === 'string') {
+      const newUrl = callback(element.attrs.src);
+      if (element.attrs) {
+        element.attrs.src = newUrl;
+      }
+    }
+    if (element.content) {
+      walkAndReplaceImages(element, callback);
+    }
+  }
+}
+
+export function tryParseInlineProxyUrl(url: string) {
+  try {
+    const urlObject = new URL(url);
+    const [base, orgShortcode, attachmentPublicId, fileName] =
+      urlObject.pathname.split('/').splice(1);
+    if (
+      base !== 'inline-proxy' ||
+      !orgShortcode ||
+      !validateTypeId('convoAttachments', attachmentPublicId) ||
+      !fileName
+    )
+      return null;
+    const fileType = decodeURIComponent(
+      urlObject.searchParams.get('type') ?? 'image/png'
+    );
+    const size = Number(urlObject.searchParams.get('size') ?? 0) || 0;
+
+    return {
+      orgShortcode,
+      attachmentPublicId,
+      fileName,
+      fileType,
+      size,
+      inline: true
+    };
+  } catch (e) {
+    return null;
+  }
+}

--- a/apps/storage/app.ts
+++ b/apps/storage/app.ts
@@ -10,6 +10,7 @@ import {
 import { deleteAttachmentsApi } from './api/deleteAttachments';
 import { internalPresignApi } from './api/internalPresign';
 import { attachmentProxy } from './proxy/attachment';
+import { inlineProxy } from './proxy/inline-proxy';
 import { deleteOrgsApi } from './api/deleteOrg';
 import { opentelemetry } from '@u22n/otel/hono';
 import { mailfetchApi } from './api/mailfetch';
@@ -34,6 +35,7 @@ app.use('*', authMiddleware);
 // Proxies
 app.route('/avatar', avatarProxy);
 app.route('/attachment', attachmentProxy);
+app.route('/inline-proxy', inlineProxy);
 
 // APIs
 app.route('/api', avatarApi);

--- a/apps/storage/ctx.ts
+++ b/apps/storage/ctx.ts
@@ -1,9 +1,9 @@
 import type { HonoContext } from '@u22n/hono';
+import type { Session } from './storage';
 
 export type Ctx = HonoContext<{
   account: {
     id: number;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    session: any;
+    session: Session;
   } | null;
 }>;

--- a/apps/storage/middlewares.ts
+++ b/apps/storage/middlewares.ts
@@ -14,7 +14,7 @@ export const authMiddleware = createMiddleware<Ctx>(async (c, next) =>
     if (!sessionCookie) {
       c.set('account', null);
     } else {
-      const sessionObject = await storage.getItem(sessionCookie);
+      const sessionObject = await storage.session.getItem(sessionCookie);
 
       if (sessionObject) {
         span?.setAttributes(

--- a/apps/storage/proxy/inline-proxy.ts
+++ b/apps/storage/proxy/inline-proxy.ts
@@ -1,0 +1,81 @@
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { pendingAttachments } from '@u22n/database/schema';
+import { GetObjectCommand } from '@aws-sdk/client-s3';
+import { typeIdValidator } from '@u22n/utils/typeid';
+import { zValidator } from '@u22n/hono/helpers';
+import { checkSignedIn } from '../middlewares';
+import { createHonoApp } from '@u22n/hono';
+import { eq } from '@u22n/database/orm';
+import { db } from '@u22n/database';
+import type { Ctx } from '../ctx';
+import { s3Client } from '../s3';
+import { env } from '../env';
+import { z } from 'zod';
+
+export const inlineProxy = createHonoApp<Ctx>()
+  .use(checkSignedIn)
+  .get(
+    '/:orgShortcode/:attachmentId/:filename',
+    zValidator(
+      'param',
+      z.object({
+        filename: z.string().transform((f) => decodeURIComponent(f)),
+        attachmentId: typeIdValidator('convoAttachments'),
+        orgShortcode: z.string()
+      })
+    ),
+    async (c) => {
+      const { filename, attachmentId, orgShortcode } = c.req.valid('param');
+
+      const attachmentQueryResponse =
+        await db.query.pendingAttachments.findFirst({
+          where: eq(pendingAttachments.publicId, attachmentId),
+          columns: {
+            filename: true
+          },
+          with: {
+            org: {
+              columns: {
+                shortcode: true,
+                publicId: true
+              },
+              with: {
+                members: {
+                  columns: {
+                    accountId: true
+                  }
+                }
+              }
+            }
+          }
+        });
+
+      if (
+        !attachmentQueryResponse ||
+        attachmentQueryResponse.filename !== filename ||
+        attachmentQueryResponse.org.shortcode !== orgShortcode ||
+        !attachmentQueryResponse.org.members.find(
+          (member) => member.accountId === c.get('account')?.id
+        )
+      ) {
+        return c.json(
+          { error: `Attachment ${filename} not found` },
+          { status: 404 }
+        );
+      }
+
+      const command = new GetObjectCommand({
+        Bucket: env.STORAGE_S3_BUCKET_ATTACHMENTS,
+        Key: `${attachmentQueryResponse.org.publicId}/${attachmentId}/${filename}`
+      });
+      const url = await getSignedUrl(s3Client, command, { expiresIn: 3600 });
+      const res = await fetch(url).then((res) => c.body(res.body, res));
+      if (!res.ok) {
+        return c.json(
+          { error: 'Error while fetching attachment' },
+          { status: 500 }
+        );
+      }
+      return res;
+    }
+  );

--- a/apps/web/src/app/[orgShortcode]/convo/[convoId]/_components/messages-panel.tsx
+++ b/apps/web/src/app/[orgShortcode]/convo/[convoId]/_components/messages-panel.tsx
@@ -25,7 +25,7 @@ import { emailIdentityAtom, replyToMessageAtom } from '../atoms';
 import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso';
 import { OriginalMessageView } from './original-message-view';
 import { type RouterOutputs, platform } from '@/src/lib/trpc';
-import { tipTapExtensions } from '@u22n/tiptap/extensions';
+import { createExtensionSet } from '@u22n/tiptap/extensions';
 import { useOrgShortcode } from '@/src/hooks/use-params';
 import { type formatParticipantData } from '../../utils';
 import { useCopyToClipboard } from '@uidotdev/usehooks';
@@ -35,6 +35,7 @@ import { type TypeId } from '@u22n/utils/typeid';
 import { cva } from 'class-variance-authority';
 import { cn } from '@/src/lib/utils';
 import { ms } from '@u22n/utils/ms';
+import { env } from '@/src/env';
 import { useAtom } from 'jotai';
 import { toast } from 'sonner';
 
@@ -207,6 +208,10 @@ export const MessagesPanel = memo(
 );
 
 MessagesPanel.displayName = 'MessagesPanel';
+
+const tipTapExtensions = createExtensionSet({
+  storageUrl: env.NEXT_PUBLIC_STORAGE_URL
+});
 
 const MessageItem = memo(
   function MessageItem({

--- a/apps/web/src/app/[orgShortcode]/convo/[convoId]/_components/reply-box.tsx
+++ b/apps/web/src/app/[orgShortcode]/convo/[convoId]/_components/reply-box.tsx
@@ -39,7 +39,6 @@ import { type TypeId } from '@u22n/utils/typeid';
 import { useDebounce } from '@uidotdev/usehooks';
 import { useAtom, useAtomValue } from 'jotai';
 import { platform } from '@/src/lib/trpc';
-import { stringify } from 'superjson';
 import { cn } from '@/src/lib/utils';
 import { ms } from '@u22n/utils/ms';
 import { toast } from 'sonner';
@@ -82,11 +81,10 @@ export function ReplyBox({
     const contentArray = editorText?.content;
     if (!contentArray) return true;
     if (contentArray.length === 0) return true;
-    if (
-      contentArray[0] &&
-      (!contentArray[0].content || contentArray[0].content.length === 0)
-    )
-      return true;
+    const firstElementWithContent = contentArray.find(
+      (element) => element.content?.length && element.content.length > 0
+    );
+    if (!firstElementWithContent) return true;
     return false;
   }, []);
 
@@ -121,7 +119,8 @@ export function ReplyBox({
     openFilePicker,
     getTrpcUploadFormat,
     AttachmentArray,
-    removeAllAttachments
+    removeAllAttachments,
+    canUpload
   } = useAttachmentUploader(draft.attachments);
 
   // Autosave draft
@@ -154,7 +153,7 @@ export function ReplyBox({
       const { publicId, bodyPlainText } = await replyToConvo({
         attachments: getTrpcUploadFormat(),
         orgShortcode,
-        message: stringify(editorText),
+        message: editorText,
         replyToMessagePublicId: replyTo,
         messageType: type,
         sendAsEmailIdentityPublicId: emailIdentity ?? undefined
@@ -217,6 +216,7 @@ export function ReplyBox({
         <Editor
           initialValue={editorText}
           onChange={setEditorText}
+          canUpload={canUpload}
           ref={editorRef}
         />
         <AttachmentArray attachments={attachments} />

--- a/apps/web/src/hooks/use-inline-uploader.ts
+++ b/apps/web/src/hooks/use-inline-uploader.ts
@@ -1,0 +1,72 @@
+import { createImageUpload } from '@u22n/tiptap/extensions/image-uploader';
+import { type TypeId } from '@u22n/utils/typeid';
+import { useOrgShortcode } from './use-params';
+import uploadTracker from '../lib/upload';
+import { useMemo } from 'react';
+import { toast } from 'sonner';
+import { env } from '../env';
+
+export function useInlineUploader(sizeValidate?: (file: File) => boolean) {
+  const orgShortcode = useOrgShortcode();
+
+  const uploader = useMemo(
+    () =>
+      createImageUpload({
+        validateFn: (file) => {
+          if (!file.type.startsWith('image/')) {
+            toast.error('Unsupported file type. Please upload an image.');
+            return false;
+          }
+          if (sizeValidate && !sizeValidate(file)) {
+            toast.error(
+              `Your are crossing the total attachment size limit, try uploading a smaller image.`
+            );
+            return false;
+          }
+          return true;
+        },
+        onUpload: async (file) => {
+          const presignedData = (await fetch(
+            `${env.NEXT_PUBLIC_STORAGE_URL}/api/attachments/presign?orgShortcode=${orgShortcode}&filename=${file.name}`,
+            {
+              method: 'GET',
+              credentials: 'include'
+            }
+          ).then((res) => res.json())) as {
+            publicId: TypeId<'convoAttachments'>;
+            signedUrl: string;
+          };
+          return new Promise((resolve, reject) => {
+            toast.promise(
+              uploadTracker({
+                formData: file,
+                method: 'PUT',
+                url: presignedData.signedUrl,
+                headers: {
+                  'Content-Type': file.type
+                },
+                includeCredentials: false
+              }).then(() => {
+                const image = new Image();
+                image.src = `${env.NEXT_PUBLIC_STORAGE_URL}/inline-proxy/${orgShortcode}/${presignedData.publicId}/${file.name}?type=${encodeURIComponent(file.type)}&size=${file.size}`;
+                image.onload = () => {
+                  resolve(image.src);
+                };
+                image.onerror = () => {
+                  reject(new Error('Failed to load image'));
+                };
+              }),
+              {
+                loading: 'Uploading Image',
+                success: 'Uploaded',
+                error: 'Upload failed'
+              }
+            );
+          });
+        }
+      }),
+    [orgShortcode, sizeValidate]
+  );
+
+  return uploader;
+}

--- a/packages/tiptap/extensions/image-uploader.ts
+++ b/packages/tiptap/extensions/image-uploader.ts
@@ -1,0 +1,164 @@
+/* eslint-disable @typescript-eslint/ban-types */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+
+import { Decoration, DecorationSet, type EditorView } from '@tiptap/pm/view';
+import { type EditorState, Plugin, PluginKey } from '@tiptap/pm/state';
+
+const uploadKey = new PluginKey('upload-image');
+
+export const UploadImagesPlugin = ({ imageClass }: { imageClass: string }) =>
+  new Plugin({
+    key: uploadKey,
+    state: {
+      init() {
+        return DecorationSet.empty;
+      },
+      apply(tr, set) {
+        set = set.map(tr.mapping, tr.doc);
+        // See if the transaction adds or removes any placeholders
+        //@ts-expect-error - not yet sure what the type I need here
+        const action = tr.getMeta(this);
+        if (action?.add) {
+          const { id, pos, src } = action.add;
+
+          const placeholder = document.createElement('div');
+          placeholder.setAttribute('class', 'img-placeholder');
+          const image = document.createElement('img');
+          image.setAttribute('class', imageClass);
+          image.src = src;
+          placeholder.appendChild(image);
+          const deco = Decoration.widget(pos + 1, placeholder, {
+            id
+          });
+          set = set.add(tr.doc, [deco]);
+        } else if (action?.remove) {
+          set = set.remove(
+            set.find(
+              undefined,
+              undefined,
+              (spec) => spec.id == action.remove.id
+            )
+          );
+        }
+        return set;
+      }
+    },
+    props: {
+      decorations(state) {
+        return this.getState(state);
+      }
+    }
+  });
+
+function findPlaceholder(state: EditorState, id: {}) {
+  const decos = uploadKey.getState(state) as DecorationSet;
+  const found = decos.find(undefined, undefined, (spec) => spec.id == id);
+  return found.length ? found[0]?.from : null;
+}
+
+export interface ImageUploadOptions {
+  validateFn?: (file: File) => void;
+  onUpload: (file: File) => Promise<unknown>;
+}
+
+export const createImageUpload =
+  ({ validateFn, onUpload }: ImageUploadOptions): UploadFn =>
+  (file, view, pos) => {
+    // check if the file is an image
+    const validated = validateFn?.(file);
+    if (!validated) return;
+    // A fresh object to act as the ID for this upload
+    const id = {};
+
+    // Replace the selection with a placeholder
+    const tr = view.state.tr;
+    if (!tr.selection.empty) tr.deleteSelection();
+
+    const reader = new FileReader();
+    reader.readAsDataURL(file);
+    reader.onload = () => {
+      tr.setMeta(uploadKey, {
+        add: {
+          id,
+          pos,
+          src: reader.result
+        }
+      });
+      view.dispatch(tr);
+    };
+
+    onUpload(file).then(
+      (src) => {
+        const { schema } = view.state;
+
+        const pos = findPlaceholder(view.state, id);
+
+        // If the content around the placeholder has been deleted, drop
+        // the image
+        if (pos == null) return;
+
+        // Otherwise, insert it at the placeholder's position, and remove
+        // the placeholder
+
+        // When BLOB_READ_WRITE_TOKEN is not valid or unavailable, read
+        // the image locally
+        const imageSrc = typeof src === 'object' ? reader.result : src;
+
+        const node = schema.nodes.image?.create({ src: imageSrc });
+        if (!node) return;
+
+        const transaction = view.state.tr
+          .replaceWith(pos, pos, node)
+          .setMeta(uploadKey, { remove: { id } });
+        view.dispatch(transaction);
+      },
+      () => {
+        // Deletes the image placeholder on error
+        // eslint-disable-next-line drizzle/enforce-delete-with-where
+        const transaction = view.state.tr
+          .delete(pos, pos)
+          .setMeta(uploadKey, { remove: { id } });
+        view.dispatch(transaction);
+      }
+    );
+  };
+
+export type UploadFn = (file: File, view: EditorView, pos: number) => void;
+
+export const handleImagePaste = (
+  view: EditorView,
+  event: ClipboardEvent,
+  uploadFn: UploadFn
+) => {
+  if (event.clipboardData?.files.length) {
+    event.preventDefault();
+    const [file] = Array.from(event.clipboardData.files);
+    const pos = view.state.selection.from;
+
+    if (file) uploadFn(file, view, pos);
+    return true;
+  }
+  return false;
+};
+
+export const handleImageDrop = (
+  view: EditorView,
+  event: DragEvent,
+  moved: boolean,
+  uploadFn: UploadFn
+) => {
+  if (!moved && event.dataTransfer?.files.length) {
+    event.preventDefault();
+    const [file] = Array.from(event.dataTransfer.files);
+    const coordinates = view.posAtCoords({
+      left: event.clientX,
+      top: event.clientY
+    });
+    // here we deduct 1 from the pos or else the image will create an extra node
+    if (file) uploadFn(file, view, coordinates?.pos ?? 0 - 1);
+    return true;
+  }
+  return false;
+};

--- a/packages/tiptap/package.json
+++ b/packages/tiptap/package.json
@@ -7,6 +7,7 @@
     "./react": "./react.ts",
     "./extensions": "./extensions/index.ts",
     "./extensions/slash-command": "./extensions/slash-command.ts",
+    "./extensions/image-uploader": "./extensions/image-uploader.ts",
     "./components": "./components/index.ts"
   },
   "scripts": {
@@ -19,7 +20,6 @@
     "@radix-ui/react-slot": "^1.1.0",
     "@tiptap/core": "^2.5.8",
     "@tiptap/extension-color": "^2.5.8",
-    "@tiptap/extension-image": "^2.5.8",
     "@tiptap/extension-link": "^2.5.8",
     "@tiptap/extension-placeholder": "^2.5.8",
     "@tiptap/extension-subscript": "^2.5.8",
@@ -27,6 +27,7 @@
     "@tiptap/extension-text-style": "^2.5.8",
     "@tiptap/extension-underline": "^2.5.8",
     "@tiptap/html": "^2.5.8",
+    "@tiptap/pm": "^2.5.9",
     "@tiptap/react": "^2.5.8",
     "@tiptap/starter-kit": "^2.5.8",
     "@tiptap/suggestion": "^2.5.8",
@@ -34,6 +35,7 @@
     "cmdk": "^1.0.0",
     "jotai": "^2.9.1",
     "tippy.js": "^6.3.7",
+    "tiptap-extension-resize-image": "^1.1.8",
     "tiptap-markdown": "^0.8.10",
     "tunnel-rat": "^0.1.2"
   },

--- a/packages/tiptap/react.ts
+++ b/packages/tiptap/react.ts
@@ -1,6 +1,6 @@
 /**
  * This entire package is a modified version of steven-tey/novel modified to our needs
- * https://github.com/steven-tey/novel/blob
+ * https://github.com/steven-tey/novel
  *
  */
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,9 @@ importers:
       mime:
         specifier: ^4.0.4
         version: 4.0.4
+      mimetext:
+        specifier: ^3.0.24
+        version: 3.0.24
       mysql2:
         specifier: ^3.10.1
         version: 3.11.0
@@ -848,43 +851,43 @@ importers:
         version: 1.1.0(@types/react@18.3.3)(react@18.3.1)
       '@tiptap/core':
         specifier: ^2.5.8
-        version: 2.5.8(@tiptap/pm@2.5.8)
+        version: 2.5.8(@tiptap/pm@2.5.9)
       '@tiptap/extension-color':
         specifier: ^2.5.8
-        version: 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))(@tiptap/extension-text-style@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8)))
-      '@tiptap/extension-image':
-        specifier: ^2.5.8
-        version: 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))
+        version: 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))(@tiptap/extension-text-style@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9)))
       '@tiptap/extension-link':
         specifier: ^2.5.8
-        version: 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))(@tiptap/pm@2.5.8)
+        version: 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))(@tiptap/pm@2.5.9)
       '@tiptap/extension-placeholder':
         specifier: ^2.5.8
-        version: 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))(@tiptap/pm@2.5.8)
+        version: 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))(@tiptap/pm@2.5.9)
       '@tiptap/extension-subscript':
         specifier: ^2.5.8
-        version: 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))
+        version: 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))
       '@tiptap/extension-superscript':
         specifier: ^2.5.8
-        version: 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))
+        version: 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))
       '@tiptap/extension-text-style':
         specifier: ^2.5.8
-        version: 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))
+        version: 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))
       '@tiptap/extension-underline':
         specifier: ^2.5.8
-        version: 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))
+        version: 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))
       '@tiptap/html':
         specifier: ^2.5.8
-        version: 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))(@tiptap/pm@2.5.8)
+        version: 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))(@tiptap/pm@2.5.9)
+      '@tiptap/pm':
+        specifier: ^2.5.9
+        version: 2.5.9
       '@tiptap/react':
         specifier: ^2.5.8
-        version: 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))(@tiptap/pm@2.5.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))(@tiptap/pm@2.5.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tiptap/starter-kit':
         specifier: ^2.5.8
-        version: 2.5.8(@tiptap/pm@2.5.8)
+        version: 2.5.8(@tiptap/pm@2.5.9)
       '@tiptap/suggestion':
         specifier: ^2.5.8
-        version: 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))(@tiptap/pm@2.5.8)
+        version: 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))(@tiptap/pm@2.5.9)
       '@u22n/tsconfig':
         specifier: ^0.0.2
         version: 0.0.2
@@ -903,9 +906,12 @@ importers:
       tippy.js:
         specifier: ^6.3.7
         version: 6.3.7
+      tiptap-extension-resize-image:
+        specifier: ^1.1.8
+        version: 1.1.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))(@tiptap/extension-image@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9)))(@tiptap/pm@2.5.9)
       tiptap-markdown:
         specifier: ^0.8.10
-        version: 0.8.10(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))
+        version: 0.8.10(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))
       tunnel-rat:
         specifier: ^0.1.2
         version: 0.1.2(@types/react@18.3.3)(react@18.3.1)
@@ -1134,6 +1140,10 @@ packages:
   '@aws-sdk/xml-builder@3.609.0':
     resolution: {integrity: sha512-l9XxNcA4HX98rwCC2/KoiWcmEiRfZe4G+mYwDbCFT87JIMj6GBhLDkAzr/W8KAaA2IDr8Vc6J8fZPgVulxxfMA==}
     engines: {node: '>=16.0.0'}
+
+  '@babel/runtime-corejs3@7.25.0':
+    resolution: {integrity: sha512-BOehWE7MgQ8W8Qn0CQnMtg2tHPHPulcS/5AVpFvs2KCK1ET+0WqZqPvnpRpFN81gYoFopdIEJX9Sgjw3ZBccPg==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/runtime@7.24.5':
     resolution: {integrity: sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==}
@@ -3822,8 +3832,8 @@ packages:
       '@tiptap/core': ^2.5.8
       '@tiptap/pm': ^2.5.8
 
-  '@tiptap/pm@2.5.8':
-    resolution: {integrity: sha512-CVhHaTG4QNHSkvuh6HHsUR4hE+nbUnk7z+VMUedaqPU8tNqkTwWGCMbiyTc+PCsz0T9Mni7vvBR+EXgEQ3+w4g==}
+  '@tiptap/pm@2.5.9':
+    resolution: {integrity: sha512-YSUaEQVtvZnGzGjif2Tl2o9utE+6tR2Djhz0EqFUcAUEVhOMk7UYUO+r/aPfcCRraIoKKuDQzyCpjKmJicjCUA==}
 
   '@tiptap/react@2.5.8':
     resolution: {integrity: sha512-twUMm8HV7scUgR/E1hYS9N6JDtKPl7cgDiPjxTynNHc5S5f5Ecv4ns/BZRq3TMZ/JDrp4rghLvgq+ImQsLvPOA==}
@@ -4374,6 +4384,9 @@ packages:
   copy-anything@3.0.5:
     resolution: {integrity: sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==}
     engines: {node: '>=12.13'}
+
+  core-js-pure@3.38.0:
+    resolution: {integrity: sha512-8balb/HAXo06aHP58mZMtXgD8vcnXz9tUDePgqBgJgKdmTlMt+jw3ujqniuBDQXMvTzxnMpxHFeuSM3g1jWQuQ==}
 
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
@@ -5417,6 +5430,9 @@ packages:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
 
+  js-base64@3.7.7:
+    resolution: {integrity: sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==}
+
   js-cookie@3.0.5:
     resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
     engines: {node: '>=14'}
@@ -5648,6 +5664,9 @@ packages:
     resolution: {integrity: sha512-v8yqInVjhXyqP6+Kw4fV3ZzeMRqEW6FotRsKXjRS5VMTNIuXsdRoAvklpoRgSqXm6o9VNH4/C0mgedko9DdLsQ==}
     engines: {node: '>=16'}
     hasBin: true
+
+  mimetext@3.0.24:
+    resolution: {integrity: sha512-UdG1KVfcxeEfo6el91lzFG2WLLTm8DxSK/rosxx5H2Pjla50+DSsjTgr9BRAfAkbQWaxvzcaTO+bHK5ZrdKdfA==}
 
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
@@ -6710,6 +6729,13 @@ packages:
   tippy.js@6.3.7:
     resolution: {integrity: sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==}
 
+  tiptap-extension-resize-image@1.1.8:
+    resolution: {integrity: sha512-dRPCfkCCUPtlVCn7w9HHE01ANJE6pRQMPAYXmsd1Qlk8KUasePdvCQIVJMqKriAqvKYJtnRc3HfojmzZtkQq0w==}
+    peerDependencies:
+      '@tiptap/core': ^2.0.0
+      '@tiptap/extension-image': ^2.0.0
+      '@tiptap/pm': ^2.0.0
+
   tiptap-markdown@0.8.10:
     resolution: {integrity: sha512-iDVkR2BjAqkTDtFX0h94yVvE2AihCXlF0Q7RIXSJPRSR5I0PA1TMuAg6FHFpmqTn4tPxJ0by0CK7PUMlnFLGEQ==}
     peerDependencies:
@@ -7707,6 +7733,11 @@ snapshots:
     dependencies:
       '@smithy/types': 3.3.0
       tslib: 2.6.3
+
+  '@babel/runtime-corejs3@7.25.0':
+    dependencies:
+      core-js-pure: 3.38.0
+      regenerator-runtime: 0.14.1
 
   '@babel/runtime@7.24.5':
     dependencies:
@@ -9962,142 +9993,142 @@ snapshots:
 
   '@tanstack/table-core@8.19.3': {}
 
-  '@tiptap/core@2.5.8(@tiptap/pm@2.5.8)':
+  '@tiptap/core@2.5.8(@tiptap/pm@2.5.9)':
     dependencies:
-      '@tiptap/pm': 2.5.8
+      '@tiptap/pm': 2.5.9
 
-  '@tiptap/extension-blockquote@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))':
+  '@tiptap/extension-blockquote@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))':
     dependencies:
-      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.8)
+      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.9)
 
-  '@tiptap/extension-bold@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))':
+  '@tiptap/extension-bold@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))':
     dependencies:
-      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.8)
+      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.9)
 
-  '@tiptap/extension-bubble-menu@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))(@tiptap/pm@2.5.8)':
+  '@tiptap/extension-bubble-menu@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))(@tiptap/pm@2.5.9)':
     dependencies:
-      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.8)
-      '@tiptap/pm': 2.5.8
+      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.9)
+      '@tiptap/pm': 2.5.9
       tippy.js: 6.3.7
 
-  '@tiptap/extension-bullet-list@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))':
+  '@tiptap/extension-bullet-list@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))':
     dependencies:
-      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.8)
+      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.9)
 
-  '@tiptap/extension-code-block@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))(@tiptap/pm@2.5.8)':
+  '@tiptap/extension-code-block@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))(@tiptap/pm@2.5.9)':
     dependencies:
-      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.8)
-      '@tiptap/pm': 2.5.8
+      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.9)
+      '@tiptap/pm': 2.5.9
 
-  '@tiptap/extension-code@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))':
+  '@tiptap/extension-code@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))':
     dependencies:
-      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.8)
+      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.9)
 
-  '@tiptap/extension-color@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))(@tiptap/extension-text-style@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8)))':
+  '@tiptap/extension-color@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))(@tiptap/extension-text-style@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9)))':
     dependencies:
-      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.8)
-      '@tiptap/extension-text-style': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))
+      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.9)
+      '@tiptap/extension-text-style': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))
 
-  '@tiptap/extension-document@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))':
+  '@tiptap/extension-document@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))':
     dependencies:
-      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.8)
+      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.9)
 
-  '@tiptap/extension-dropcursor@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))(@tiptap/pm@2.5.8)':
+  '@tiptap/extension-dropcursor@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))(@tiptap/pm@2.5.9)':
     dependencies:
-      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.8)
-      '@tiptap/pm': 2.5.8
+      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.9)
+      '@tiptap/pm': 2.5.9
 
-  '@tiptap/extension-floating-menu@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))(@tiptap/pm@2.5.8)':
+  '@tiptap/extension-floating-menu@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))(@tiptap/pm@2.5.9)':
     dependencies:
-      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.8)
-      '@tiptap/pm': 2.5.8
+      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.9)
+      '@tiptap/pm': 2.5.9
       tippy.js: 6.3.7
 
-  '@tiptap/extension-gapcursor@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))(@tiptap/pm@2.5.8)':
+  '@tiptap/extension-gapcursor@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))(@tiptap/pm@2.5.9)':
     dependencies:
-      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.8)
-      '@tiptap/pm': 2.5.8
+      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.9)
+      '@tiptap/pm': 2.5.9
 
-  '@tiptap/extension-hard-break@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))':
+  '@tiptap/extension-hard-break@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))':
     dependencies:
-      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.8)
+      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.9)
 
-  '@tiptap/extension-heading@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))':
+  '@tiptap/extension-heading@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))':
     dependencies:
-      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.8)
+      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.9)
 
-  '@tiptap/extension-history@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))(@tiptap/pm@2.5.8)':
+  '@tiptap/extension-history@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))(@tiptap/pm@2.5.9)':
     dependencies:
-      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.8)
-      '@tiptap/pm': 2.5.8
+      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.9)
+      '@tiptap/pm': 2.5.9
 
-  '@tiptap/extension-horizontal-rule@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))(@tiptap/pm@2.5.8)':
+  '@tiptap/extension-horizontal-rule@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))(@tiptap/pm@2.5.9)':
     dependencies:
-      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.8)
-      '@tiptap/pm': 2.5.8
+      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.9)
+      '@tiptap/pm': 2.5.9
 
-  '@tiptap/extension-image@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))':
+  '@tiptap/extension-image@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))':
     dependencies:
-      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.8)
+      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.9)
 
-  '@tiptap/extension-italic@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))':
+  '@tiptap/extension-italic@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))':
     dependencies:
-      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.8)
+      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.9)
 
-  '@tiptap/extension-link@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))(@tiptap/pm@2.5.8)':
+  '@tiptap/extension-link@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))(@tiptap/pm@2.5.9)':
     dependencies:
-      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.8)
-      '@tiptap/pm': 2.5.8
+      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.9)
+      '@tiptap/pm': 2.5.9
       linkifyjs: 4.1.3
 
-  '@tiptap/extension-list-item@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))':
+  '@tiptap/extension-list-item@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))':
     dependencies:
-      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.8)
+      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.9)
 
-  '@tiptap/extension-ordered-list@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))':
+  '@tiptap/extension-ordered-list@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))':
     dependencies:
-      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.8)
+      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.9)
 
-  '@tiptap/extension-paragraph@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))':
+  '@tiptap/extension-paragraph@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))':
     dependencies:
-      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.8)
+      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.9)
 
-  '@tiptap/extension-placeholder@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))(@tiptap/pm@2.5.8)':
+  '@tiptap/extension-placeholder@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))(@tiptap/pm@2.5.9)':
     dependencies:
-      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.8)
-      '@tiptap/pm': 2.5.8
+      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.9)
+      '@tiptap/pm': 2.5.9
 
-  '@tiptap/extension-strike@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))':
+  '@tiptap/extension-strike@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))':
     dependencies:
-      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.8)
+      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.9)
 
-  '@tiptap/extension-subscript@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))':
+  '@tiptap/extension-subscript@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))':
     dependencies:
-      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.8)
+      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.9)
 
-  '@tiptap/extension-superscript@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))':
+  '@tiptap/extension-superscript@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))':
     dependencies:
-      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.8)
+      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.9)
 
-  '@tiptap/extension-text-style@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))':
+  '@tiptap/extension-text-style@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))':
     dependencies:
-      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.8)
+      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.9)
 
-  '@tiptap/extension-text@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))':
+  '@tiptap/extension-text@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))':
     dependencies:
-      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.8)
+      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.9)
 
-  '@tiptap/extension-underline@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))':
+  '@tiptap/extension-underline@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))':
     dependencies:
-      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.8)
+      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.9)
 
-  '@tiptap/html@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))(@tiptap/pm@2.5.8)':
+  '@tiptap/html@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))(@tiptap/pm@2.5.9)':
     dependencies:
-      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.8)
-      '@tiptap/pm': 2.5.8
+      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.9)
+      '@tiptap/pm': 2.5.9
       zeed-dom: 0.10.11
 
-  '@tiptap/pm@2.5.8':
+  '@tiptap/pm@2.5.9':
     dependencies:
       prosemirror-changeset: 2.2.1
       prosemirror-collab: 1.3.1
@@ -10118,45 +10149,45 @@ snapshots:
       prosemirror-transform: 1.9.0
       prosemirror-view: 1.33.9
 
-  '@tiptap/react@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))(@tiptap/pm@2.5.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@tiptap/react@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))(@tiptap/pm@2.5.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.8)
-      '@tiptap/extension-bubble-menu': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))(@tiptap/pm@2.5.8)
-      '@tiptap/extension-floating-menu': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))(@tiptap/pm@2.5.8)
-      '@tiptap/pm': 2.5.8
+      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.9)
+      '@tiptap/extension-bubble-menu': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))(@tiptap/pm@2.5.9)
+      '@tiptap/extension-floating-menu': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))(@tiptap/pm@2.5.9)
+      '@tiptap/pm': 2.5.9
       '@types/use-sync-external-store': 0.0.6
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       use-sync-external-store: 1.2.2(react@18.3.1)
 
-  '@tiptap/starter-kit@2.5.8(@tiptap/pm@2.5.8)':
+  '@tiptap/starter-kit@2.5.8(@tiptap/pm@2.5.9)':
     dependencies:
-      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.8)
-      '@tiptap/extension-blockquote': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))
-      '@tiptap/extension-bold': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))
-      '@tiptap/extension-bullet-list': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))
-      '@tiptap/extension-code': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))
-      '@tiptap/extension-code-block': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))(@tiptap/pm@2.5.8)
-      '@tiptap/extension-document': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))
-      '@tiptap/extension-dropcursor': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))(@tiptap/pm@2.5.8)
-      '@tiptap/extension-gapcursor': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))(@tiptap/pm@2.5.8)
-      '@tiptap/extension-hard-break': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))
-      '@tiptap/extension-heading': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))
-      '@tiptap/extension-history': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))(@tiptap/pm@2.5.8)
-      '@tiptap/extension-horizontal-rule': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))(@tiptap/pm@2.5.8)
-      '@tiptap/extension-italic': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))
-      '@tiptap/extension-list-item': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))
-      '@tiptap/extension-ordered-list': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))
-      '@tiptap/extension-paragraph': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))
-      '@tiptap/extension-strike': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))
-      '@tiptap/extension-text': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))
+      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.9)
+      '@tiptap/extension-blockquote': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))
+      '@tiptap/extension-bold': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))
+      '@tiptap/extension-bullet-list': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))
+      '@tiptap/extension-code': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))
+      '@tiptap/extension-code-block': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))(@tiptap/pm@2.5.9)
+      '@tiptap/extension-document': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))
+      '@tiptap/extension-dropcursor': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))(@tiptap/pm@2.5.9)
+      '@tiptap/extension-gapcursor': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))(@tiptap/pm@2.5.9)
+      '@tiptap/extension-hard-break': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))
+      '@tiptap/extension-heading': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))
+      '@tiptap/extension-history': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))(@tiptap/pm@2.5.9)
+      '@tiptap/extension-horizontal-rule': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))(@tiptap/pm@2.5.9)
+      '@tiptap/extension-italic': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))
+      '@tiptap/extension-list-item': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))
+      '@tiptap/extension-ordered-list': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))
+      '@tiptap/extension-paragraph': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))
+      '@tiptap/extension-strike': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))
+      '@tiptap/extension-text': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))
     transitivePeerDependencies:
       - '@tiptap/pm'
 
-  '@tiptap/suggestion@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.8))(@tiptap/pm@2.5.8)':
+  '@tiptap/suggestion@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))(@tiptap/pm@2.5.9)':
     dependencies:
-      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.8)
-      '@tiptap/pm': 2.5.8
+      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.9)
+      '@tiptap/pm': 2.5.9
 
   '@trpc/client@11.0.0-rc.467(@trpc/server@11.0.0-rc.467)':
     dependencies:
@@ -10783,6 +10814,8 @@ snapshots:
   copy-anything@3.0.5:
     dependencies:
       is-what: 4.1.16
+
+  core-js-pure@3.38.0: {}
 
   crelt@1.0.6: {}
 
@@ -11999,6 +12032,8 @@ snapshots:
 
   joycon@3.1.1: {}
 
+  js-base64@3.7.7: {}
+
   js-cookie@3.0.5: {}
 
   js-tokens@4.0.0: {}
@@ -12287,6 +12322,13 @@ snapshots:
   mime@3.0.0: {}
 
   mime@4.0.4: {}
+
+  mimetext@3.0.24:
+    dependencies:
+      '@babel/runtime': 7.24.5
+      '@babel/runtime-corejs3': 7.25.0
+      js-base64: 3.7.7
+      mime-types: 2.1.35
 
   mimic-fn@2.1.0: {}
 
@@ -13408,9 +13450,15 @@ snapshots:
     dependencies:
       '@popperjs/core': 2.11.8
 
-  tiptap-markdown@0.8.10(@tiptap/core@2.5.8(@tiptap/pm@2.5.8)):
+  tiptap-extension-resize-image@1.1.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))(@tiptap/extension-image@2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9)))(@tiptap/pm@2.5.9):
     dependencies:
-      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.8)
+      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.9)
+      '@tiptap/extension-image': 2.5.8(@tiptap/core@2.5.8(@tiptap/pm@2.5.9))
+      '@tiptap/pm': 2.5.9
+
+  tiptap-markdown@0.8.10(@tiptap/core@2.5.8(@tiptap/pm@2.5.9)):
+    dependencies:
+      '@tiptap/core': 2.5.8(@tiptap/pm@2.5.9)
       '@types/markdown-it': 13.0.8
       markdown-it: 14.1.0
       markdown-it-task-lists: 2.1.1


### PR DESCRIPTION
## What does this PR do?

Fixes #680 

## What has changed
- Emails are now sent as raw emails to postal so that we can support inline attachments and use convoId and convo entryId as custom Message-Id
- Inline Images are supported via pendingAttachment table and inline-proxy api, while submitting the convo the urls are replaced with correct attachments in platform and `cid` with attached inlined attachments
- extra changes, functions and hooks to support inline images

## How to test
As there are core changes we need to test everything with sending emails, receiving emails, etc

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Tested my code in a local environment
- [ ] Commented on my code in hard-to-understand areas
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the UnInbox Docs if changes were necessary
