### PR TITLE
chore: fix TTL for redis from ms to seconds

### DIFF
--- a/apps/platform/storage.ts
+++ b/apps/platform/storage.ts
@@ -2,8 +2,8 @@ import { createStorage, type Driver, type StorageValue } from 'unstorage';
 import redisDriver from 'unstorage/drivers/redis';
 import type { TypeId } from '@u22n/utils/typeid';
 import type { DatabaseSession } from 'lucia';
+import { seconds } from '@u22n/utils/ms';
 import type { OrgContext } from './ctx';
-import { ms } from '@u22n/utils/ms';
 import { env } from './env';
 
 const createCachedStorage = <T extends StorageValue = StorageValue>(
@@ -21,40 +21,43 @@ const createCachedStorage = <T extends StorageValue = StorageValue>(
 export const storage = {
   passkeyChallenges: createCachedStorage<PasskeyChallenges>(
     'passkey-challenges',
-    ms('5 minutes')
+    seconds('5 minutes')
   ),
   twoFactorLoginChallenges: createCachedStorage<TwoFactorLoginChallenges>(
     'two-factor-login-challenges',
-    ms('5 minutes')
+    seconds('5 minutes')
   ),
   twoFactorResetChallenges: createCachedStorage<TwoFactorResetChallenges>(
     'two-factor-reset-challenges',
-    ms('5 minutes')
+    seconds('5 minutes')
   ),
   // used when a user wants to recover a password
   accountRecoveryVerificationCodes:
     createCachedStorage<AccountRecoveryVerificationCodes>(
       'account-recovery-verification-codes',
-      ms('15 minutes')
+      seconds('15 minutes')
     ),
   // used when user adds a recovery email
   recoveryEmailVerificationCodes:
     createCachedStorage<RecoveryEmailVerificationCodes>(
       'recovery-email-verification-codes',
-      ms('15 minutes')
+      seconds('15 minutes')
     ),
   elevatedTokens: createCachedStorage<ElevatedTokens>(
     'elevated-tokens',
-    ms('5 minutes')
+    seconds('5 minutes')
   ),
-  orgContext: createCachedStorage<OrgContext>('org-context', ms('12 hours')),
+  orgContext: createCachedStorage<OrgContext>(
+    'org-context',
+    seconds('12 hours')
+  ),
   session: createCachedStorage<DatabaseSession>(
     'sessions',
-    env.NODE_ENV === 'development' ? ms('12 hours') : ms('30 days')
+    env.NODE_ENV === 'development' ? seconds('12 hours') : seconds('30 days')
   ),
   resetTokens: createCachedStorage<ResetTokens>(
     'reset-tokens',
-    ms('15 minutes')
+    seconds('15 minutes')
   )
 };
 


### PR DESCRIPTION
## What does this PR do?

We had redis TTL using `ms(...)` while it takes seconds as argument, which made everything last 1000x longer, now they use `seconds(...)` which fixes the issue

FIxes ENG-132

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Tested my code in a local environment
- [ ] Commented on my code in hard-to-understand areas
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the UnInbox Docs if changes were necessary
