### PR TITLE
fix: automatically select correct email identity when replying

### DIFF
--- a/apps/web/src/app/[orgShortcode]/convo/[convoId]/_components/convo-views.tsx
+++ b/apps/web/src/app/[orgShortcode]/convo/[convoId]/_components/convo-views.tsx
@@ -5,6 +5,7 @@ import { usePageTitle } from '@/src/hooks/use-page-title';
 import { type VirtuosoHandle } from 'react-virtuoso';
 import { useCallback, useMemo, useRef } from 'react';
 import { formatParticipantData } from '../../utils';
+import { SpinnerGap } from '@phosphor-icons/react';
 import { type TypeId } from '@u22n/utils/typeid';
 import { MessagesPanel } from './messages-panel';
 import { platform } from '@/src/lib/trpc';
@@ -75,14 +76,6 @@ export function ConvoView({ convoId }: { convoId: TypeId<'convos'> }) {
     [formattedParticipants]
   );
 
-  const defaultEmailIdentity = useMemo(
-    () =>
-      convoData?.data.participants.find(
-        (p) => p.publicId === participantOwnPublicId
-      )?.emailIdentity?.publicId,
-    [convoData?.data.participants, participantOwnPublicId]
-  );
-
   const onReply = useCallback(
     () => virtuosoRef.current?.scrollToIndex({ index: 'LAST' }),
     []
@@ -102,26 +95,33 @@ export function ConvoView({ convoId }: { convoId: TypeId<'convos'> }) {
         participants={formattedParticipants}
         attachments={attachments}
       />
-      <div className="flex w-full flex-1 flex-col">
-        {convoDataLoading || !participantOwnPublicId ? (
-          <span>Loading</span>
-        ) : (
-          <MessagesPanel
-            convoId={convoId}
-            formattedParticipants={formattedParticipants}
-            participantOwnPublicId={
-              participantOwnPublicId as TypeId<'convoParticipants'>
-            }
-            ref={virtuosoRef}
+      {convoDataLoading || !participantOwnPublicId ? (
+        <div className="flex h-full w-full items-center justify-center gap-2 text-center font-bold">
+          <SpinnerGap
+            className="size-4 animate-spin"
+            size={16}
           />
-        )}
-      </div>
-      <ReplyBox
-        convoId={convoId}
-        onReply={onReply}
-        hasExternalParticipants={hasExternalParticipants}
-        defaultEmailIdentity={defaultEmailIdentity}
-      />
+          <span>Loading...</span>
+        </div>
+      ) : (
+        <>
+          <div className="flex w-full flex-1 flex-col">
+            <MessagesPanel
+              convoId={convoId}
+              formattedParticipants={formattedParticipants}
+              participantOwnPublicId={
+                participantOwnPublicId as TypeId<'convoParticipants'>
+              }
+              ref={virtuosoRef}
+            />
+          </div>
+          <ReplyBox
+            convoId={convoId}
+            onReply={onReply}
+            hasExternalParticipants={hasExternalParticipants}
+          />
+        </>
+      )}
     </div>
   );
 }

--- a/apps/web/src/app/[orgShortcode]/convo/[convoId]/_components/reply-box.tsx
+++ b/apps/web/src/app/[orgShortcode]/convo/[convoId]/_components/reply-box.tsx
@@ -29,35 +29,31 @@ import {
 import { useAttachmentUploader } from '@/src/components/shared/attachments';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useGlobalStore } from '@/src/providers/global-store-provider';
+import { emailIdentityAtom, replyToMessageAtom } from '../atoms';
 import { Button } from '@/src/components/shadcn-ui/button';
 import { useIsMobile } from '@/src/hooks/use-is-mobile';
 import { emptyTiptapEditorContent } from '@u22n/tiptap';
 import { useDraft } from '@/src/stores/draft-store';
-import { atom, useAtom, useAtomValue } from 'jotai';
 import { Editor } from '@/src/components/editor';
 import { type TypeId } from '@u22n/utils/typeid';
 import { useDebounce } from '@uidotdev/usehooks';
-import { replyToMessageAtom } from '../atoms';
+import { useAtom, useAtomValue } from 'jotai';
 import { platform } from '@/src/lib/trpc';
 import { stringify } from 'superjson';
 import { cn } from '@/src/lib/utils';
 import { ms } from '@u22n/utils/ms';
 import { toast } from 'sonner';
 
-const selectedEmailIdentityAtom = atom<null | TypeId<'emailIdentities'>>(null);
-
 type ReplyBoxProps = {
   convoId: TypeId<'convos'>;
   onReply: () => void;
   hasExternalParticipants: boolean;
-  defaultEmailIdentity?: TypeId<'emailIdentities'>;
 };
 
 export function ReplyBox({
   convoId,
   onReply,
-  hasExternalParticipants,
-  defaultEmailIdentity
+  hasExternalParticipants
 }: ReplyBoxProps) {
   const { draft, setDraft, resetDraft } = useDraft(convoId);
   const [editorText, setEditorText] = useState(draft.content);
@@ -99,8 +95,6 @@ export function ReplyBox({
     [emptyEditorChecker, editorText]
   );
 
-  const [emailIdentity, setEmailIdentity] = useAtom(selectedEmailIdentityAtom);
-
   const { data: emailIdentities, isLoading: emailIdentitiesLoading } =
     platform.org.mail.emailIdentities.getUserEmailIdentities.useQuery(
       {
@@ -120,17 +114,7 @@ export function ReplyBox({
       }
     );
 
-  useEffect(() => {
-    setEmailIdentity((prev) => {
-      if (prev) return prev;
-      return (
-        defaultEmailIdentity ??
-        emailIdentities?.defaultEmailIdentity ??
-        emailIdentities?.emailIdentities[0]?.publicId ??
-        null
-      );
-    });
-  }, [defaultEmailIdentity, emailIdentities, setEmailIdentity]);
+  const [emailIdentity, setEmailIdentity] = useAtom(emailIdentityAtom);
 
   const {
     attachments,

--- a/apps/web/src/app/[orgShortcode]/convo/[convoId]/atoms.ts
+++ b/apps/web/src/app/[orgShortcode]/convo/[convoId]/atoms.ts
@@ -2,3 +2,4 @@ import { type TypeId } from '@u22n/utils/typeid';
 import { atom } from 'jotai';
 
 export const replyToMessageAtom = atom<TypeId<'convoEntries'> | null>(null);
+export const emailIdentityAtom = atom<TypeId<'emailIdentities'> | null>(null);


### PR DESCRIPTION
## What does this PR do?

Automatically select the identity associated with the convo

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Tested my code in a local environment
- [ ] Commented on my code in hard-to-understand areas
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the UnInbox Docs if changes were necessary
