### PR TITLE
fix: hide bottom nav in convo and fix dialog text alignment

### DIFF
--- a/apps/web/src/app/[orgShortcode]/layout.tsx
+++ b/apps/web/src/app/[orgShortcode]/layout.tsx
@@ -1,10 +1,10 @@
 'use client';
 
+import { useCurrentConvoId, useOrgShortcode } from '@/src/hooks/use-params';
 import { ClaimEmailIdentity } from './_components/claim-email-identity';
 import { RealtimeProvider } from '@/src/providers/realtime-provider';
 import { NewConvoSheet } from './convo/_components/new-convo-sheet';
 import { Button } from '@/src/components/shadcn-ui/button';
-import { useOrgShortcode } from '@/src/hooks/use-params';
 import { useIsMobile } from '@/src/hooks/use-is-mobile';
 import { BottomNav } from './_components/bottom-nav';
 import { SpinnerGap } from '@phosphor-icons/react';
@@ -18,6 +18,7 @@ export default function Layout({
   children
 }: Readonly<{ children: React.ReactNode }>) {
   const orgShortcode = useOrgShortcode();
+  const convoId = useCurrentConvoId();
   const isMobile = useIsMobile();
 
   const { data: access, isLoading: accessLoading } =
@@ -75,7 +76,7 @@ export default function Layout({
         className={cn('bg-base-1 flex h-full gap-0', isMobile && 'flex-col')}>
         {!isMobile && <Sidebar />}
         <div className="min-w-0 flex-1 grow overflow-x-auto">{children}</div>
-        {isMobile && <BottomNav />}
+        {isMobile && !convoId && <BottomNav />}
         {!isMobile && <NewConvoSheet />}
         {hasEmailIdentity && !hasEmailIdentity.hasIdentity && (
           <ClaimEmailIdentity />

--- a/apps/web/src/components/shadcn-ui/alert-dialog.tsx
+++ b/apps/web/src/components/shadcn-ui/alert-dialog.tsx
@@ -48,10 +48,7 @@ const AlertDialogHeader = ({
   ...props
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
-    className={cn(
-      'flex flex-col space-y-2 text-center sm:text-left',
-      className
-    )}
+    className={cn('flex flex-col space-y-2 text-left', className)}
     {...props}
   />
 );

--- a/apps/web/src/components/shadcn-ui/dialog.tsx
+++ b/apps/web/src/components/shadcn-ui/dialog.tsx
@@ -55,10 +55,7 @@ const DialogHeader = ({
   ...props
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
-    className={cn(
-      'flex flex-col space-y-1.5 text-center sm:text-left',
-      className
-    )}
+    className={cn('flex flex-col space-y-1.5 text-left', className)}
     {...props}
   />
 );


### PR DESCRIPTION
## What does this PR do?

### Chnages
- Hide bottom nav on mobile while a convo is open to get more screen space
- Make dialogs left aligned on mobile too, as that looks better

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Tested my code in a local environment
- [ ] Commented on my code in hard-to-understand areas
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the UnInbox Docs if changes were necessary
