### PR TITLE
[Invite Modal] Disables "Select/Create Email Address" if no domains :black_heart:

### DIFF
--- a/apps/web/src/app/[orgShortcode]/settings/org/users/invites/_components/invite-modal.tsx
+++ b/apps/web/src/app/[orgShortcode]/settings/org/users/invites/_components/invite-modal.tsx
@@ -356,27 +356,25 @@ export function InviteModal() {
                                   </SelectContent>
                                 </Select>
                               ) : (
-                                <Tooltip>
-                                  <TooltipTrigger className="w-full">
-                                    <Select
-                                      disabled
-                                      name={field.name}
-                                      value={field.value}
-                                      onValueChange={(e: TypeId<'domains'>) =>
-                                        field.onChange(e)
-                                      }>
-                                      <FormControl>
+                                <Select
+                                  disabled
+                                  name={field.name}
+                                  value={field.value}>
+                                  <FormControl>
+                                    <Tooltip>
+                                      <TooltipTrigger asChild>
                                         <SelectTrigger className="w-full flex-1">
                                           <SelectValue placeholder="Select domain" />
                                         </SelectTrigger>
-                                      </FormControl>
-                                    </Select>
-                                  </TooltipTrigger>
-                                  <TooltipContent>
-                                    You dont have any domains to create an email
-                                    address for
-                                  </TooltipContent>
-                                </Tooltip>
+                                      </TooltipTrigger>
+                                      <TooltipContent>
+                                        {
+                                          "You don't have any domains to create an email address"
+                                        }
+                                      </TooltipContent>
+                                    </Tooltip>
+                                  </FormControl>
+                                </Select>
                               )}
                               <FormMessage />
                             </FormItem>

--- a/apps/web/src/app/[orgShortcode]/settings/org/users/invites/_components/invite-modal.tsx
+++ b/apps/web/src/app/[orgShortcode]/settings/org/users/invites/_components/invite-modal.tsx
@@ -330,29 +330,54 @@ export function InviteModal() {
                           name="email.domain"
                           render={({ field }) => (
                             <FormItem>
-                              <Select
-                                name={field.name}
-                                value={field.value}
-                                onValueChange={(e: TypeId<'domains'>) =>
-                                  field.onChange(e)
-                                }>
-                                <FormControl>
-                                  <SelectTrigger className="w-full flex-1">
-                                    <SelectValue placeholder="Select domain" />
-                                  </SelectTrigger>
-                                </FormControl>
-                                <SelectContent>
-                                  <SelectGroup>
-                                    {orgDomains.domainData.map((domain) => (
-                                      <SelectItem
-                                        key={domain.publicId}
-                                        value={domain.publicId}>
-                                        {domain.domain}
-                                      </SelectItem>
-                                    ))}
-                                  </SelectGroup>
-                                </SelectContent>
-                              </Select>
+                              {orgDomains.domainData &&
+                              orgDomains.domainData.length > 0 ? (
+                                <Select
+                                  name={field.name}
+                                  value={field.value}
+                                  onValueChange={(e: TypeId<'domains'>) =>
+                                    field.onChange(e)
+                                  }>
+                                  <FormControl>
+                                    <SelectTrigger className="w-full flex-1">
+                                      <SelectValue placeholder="Select domain" />
+                                    </SelectTrigger>
+                                  </FormControl>
+                                  <SelectContent>
+                                    <SelectGroup>
+                                      {orgDomains.domainData.map((domain) => (
+                                        <SelectItem
+                                          key={domain.publicId}
+                                          value={domain.publicId}>
+                                          {domain.domain}
+                                        </SelectItem>
+                                      ))}
+                                    </SelectGroup>
+                                  </SelectContent>
+                                </Select>
+                              ) : (
+                                <Tooltip>
+                                  <TooltipTrigger className="w-full">
+                                    <Select
+                                      disabled
+                                      name={field.name}
+                                      value={field.value}
+                                      onValueChange={(e: TypeId<'domains'>) =>
+                                        field.onChange(e)
+                                      }>
+                                      <FormControl>
+                                        <SelectTrigger className="w-full flex-1">
+                                          <SelectValue placeholder="Select domain" />
+                                        </SelectTrigger>
+                                      </FormControl>
+                                    </Select>
+                                  </TooltipTrigger>
+                                  <TooltipContent>
+                                    You dont have any domains to create an email
+                                    address for
+                                  </TooltipContent>
+                                </Tooltip>
+                              )}
                               <FormMessage />
                             </FormItem>
                           )}


### PR DESCRIPTION

Resolves: #707  

## What does this PR do?

In the Invite Modal, when an organization has no domains, the "Create Email Address" option is now disabled. This prevents users from trying to create an email address when it's not possible.

A tooltip is added to explain the limitation, informing users that they need to add a domain first to enable this option. This approach improves the user experience by preventing confusion and guiding them effectively.

Fixes #707 

## Type of change

- [ ✔️] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ✔️] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ✔️] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [ ✔️] Self-reviewed my own code
- [✔️ ] Tested my code in a local environment
- [ ✔️] Commented on my code in hard-to-understand areas
- [ ✔️] Checked for warnings, there are none
- [ ✔️] Removed all `console.logs`
- [✔️ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [✔️ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ✔️] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ✔️] Updated the UnInbox Docs if changes were necessary


![image](https://github.com/user-attachments/assets/0b78ac57-7654-4268-b1c3-014995884c98)

