### PR TITLE
fix: app crash while using old url format for convos

### DIFF
--- a/apps/web/src/app/[orgShortcode]/convo/layout.tsx
+++ b/apps/web/src/app/[orgShortcode]/convo/layout.tsx
@@ -80,7 +80,7 @@ function ConvoNavHeader(
   }
 ) {
   const orgShortcode = useOrgShortcode();
-  const spaceShortcode = useSpaceShortcode();
+  const spaceShortcode = useSpaceShortcode(false);
   const { scopedUrl } = useOrgScopedRouter();
 
   // const { mutate: hideConvo } = platform.convos.hideConvo.useMutation({
@@ -92,7 +92,7 @@ function ConvoNavHeader(
   const spaceDisplayPropertiesQuery =
     platform.spaces.getSpaceDisplayProperties.useQuery({
       orgShortcode: orgShortcode,
-      spaceShortcode: spaceShortcode
+      spaceShortcode: spaceShortcode ?? 'all'
     });
 
   const {


### PR DESCRIPTION
## What does this PR do?

While using the old `/org/convo/c_xxxxx` format the app crashes due to a space not being available. This makes it fallback to `all`

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Tested my code in a local environment
- [ ] Commented on my code in hard-to-understand areas
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the UnInbox Docs if changes were necessary
