### PR TITLE
fix:allows workflows on pro plan

### DIFF
--- a/ee/apps/billing/trpc/routers/iCanHazRouter.ts
+++ b/ee/apps/billing/trpc/routers/iCanHazRouter.ts
@@ -127,9 +127,9 @@ export const iCanHazRouter = router({
       });
       if (orgBillingResponse && orgBillingResponse.plan === 'pro') {
         allowedWorkflows = {
-          open: 1,
-          active: 1,
-          closed: 1
+          open: 5,
+          active: 8,
+          closed: 5
         };
       }
       return allowedWorkflows;


### PR DESCRIPTION
fixes https://linear.app/unn/issue/ENG-154/when-creating-space-worflows-cant-add-more-even-if-pro-plan