### PR TITLE
feat: Update convos moving b/w spaces, sync workflow with realtime

### DIFF
--- a/apps/platform/trpc/routers/spaceRouter/spaceRouter.ts
+++ b/apps/platform/trpc/routers/spaceRouter/spaceRouter.ts
@@ -292,7 +292,7 @@ export const spaceRouter = router({
       if (input.spaceShortcode === 'all') {
         return {
           space: {
-            publicId: 'lala',
+            publicId: 'all_convos',
             name: 'All Conversations',
             avatarTimestamp: null,
             color: 'cyan',

--- a/apps/web/src/app/[orgShortcode]/convo/[convoId]/_components/top-bar.tsx
+++ b/apps/web/src/app/[orgShortcode]/convo/[convoId]/_components/top-bar.tsx
@@ -826,13 +826,9 @@ function SpaceWorkflowBlockWorkflowList({
     findWorkflow(spaceWorkflows.active) ??
     findWorkflow(spaceWorkflows.closed);
 
-  const convoSpaceWorkflowCache =
-    platform.useUtils().convos.getConvoSpaceWorkflows;
-
   const { mutateAsync: setConvoWorkflow } =
     platform.convos.setConvoSpaceWorkflow.useMutation({
       onSuccess: () => {
-        void convoSpaceWorkflowCache.invalidate();
         setShowWorkflowList(false);
       }
     });

--- a/apps/web/src/app/[orgShortcode]/layout.tsx
+++ b/apps/web/src/app/[orgShortcode]/layout.tsx
@@ -100,7 +100,9 @@ const RealtimeHandlers = memo(function RealtimeHandler() {
   // const toggleConvoHidden = useToggleConvoHidden$Cache();
   const deleteConvo = useDeleteConvo$Cache();
   const updateConvoMessageList = useUpdateConvoMessageList$Cache();
-  const adminIssuesCache = platform.useUtils().org.store.getOrgIssues;
+  const utils = platform.useUtils();
+  const adminIssuesCache = utils.org.store.getOrgIssues;
+  const getConvoSpaceWorkflows = utils.convos.getConvoSpaceWorkflows;
 
   const { data: spacesData } = platform.spaces.getOrgMemberSpaces.useQuery(
     {
@@ -147,15 +149,19 @@ const RealtimeHandlers = memo(function RealtimeHandler() {
           spaceShortcode
         })
       );
+
+      listen('convo:workflow:update', ({ convoPublicId, orgShortcode }) =>
+        getConvoSpaceWorkflows.invalidate({ convoPublicId, orgShortcode })
+      );
       return unsubscribe;
     });
   }, [
     addConvo,
     client,
     deleteConvo,
+    getConvoSpaceWorkflows,
     previousSpaces,
     spacesData?.spaces,
-    // toggleConvoHidden,
     updateConvoMessageList
   ]);
 

--- a/packages/realtime/events.ts
+++ b/packages/realtime/events.ts
@@ -15,6 +15,10 @@ export const eventDataMaps = {
     convoPublicId: typeIdValidator('convos'),
     convoEntryPublicId: typeIdValidator('convoEntries')
   }),
+  'convo:workflow:update': z.object({
+    convoPublicId: typeIdValidator('convos'),
+    orgShortcode: z.string()
+  }),
   'admin:issue:refresh': z.object({})
 } as const;
 


### PR DESCRIPTION
## What does this PR do?

- Update caches while moving/adding convo to spaces
- Update workflow statues with realtime for syncing b/w every org member

Fixes ENG-150
Fixes ENG-151

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Tested my code in a local environment
- [ ] Commented on my code in hard-to-understand areas
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the UnInbox Docs if changes were necessary
