### PR TITLE
fix: random ellipsis in convo previews

### DIFF
--- a/apps/web/src/app/[orgShortcode]/convo/_components/convo-list-item.tsx
+++ b/apps/web/src/app/[orgShortcode]/convo/_components/convo-list-item.tsx
@@ -188,7 +188,7 @@ export const ConvoItem = memo(function ConvoItem({
                 )}
               </div>
 
-              <span className="line-clamp-2 overflow-ellipsis whitespace-break-spaces break-words">
+              <span className="line-clamp-2 overflow-clip break-words">
                 {convo.entries[0]?.bodyPlainText.trim() ?? ''}
               </span>
             </div>


### PR DESCRIPTION
## What does this PR do?

Fixes the word breaking for convo previews

Before:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/pdcPzzwHY7gqQNDOL86j/7e7497bd-1365-47bf-a26f-153911b25c6d.png)

After:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/pdcPzzwHY7gqQNDOL86j/1351f7ae-be1b-4556-b782-8ad9f4bcf89c.png)

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Tested my code in a local environment
- [ ] Commented on my code in hard-to-understand areas
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the UnInbox Docs if changes were necessary
