### PR TITLE
fix: update convo participants cache when replying to a unassigned convo

### DIFF
--- a/apps/web/src/app/[orgShortcode]/convo/[convoId]/_components/convo-views.tsx
+++ b/apps/web/src/app/[orgShortcode]/convo/[convoId]/_components/convo-views.tsx
@@ -48,6 +48,8 @@ export function ConvoView({ convoId }: { convoId: TypeId<'convos'> }) {
   }, [convoData, orgShortcode]);
 
   const participantOwnPublicId = convoData?.ownParticipantPublicId;
+  const utils = platform.useUtils();
+
   // const convoHidden = useMemo(
   //   () =>
   //     convoData
@@ -77,10 +79,16 @@ export function ConvoView({ convoId }: { convoId: TypeId<'convos'> }) {
     [formattedParticipants]
   );
 
-  const onReply = useCallback(
-    () => virtuosoRef.current?.scrollToIndex({ index: 'LAST' }),
-    []
-  );
+  const onReply = useCallback(async () => {
+    virtuosoRef.current?.scrollToIndex({ index: 'LAST' });
+    // Refresh the convo data if own public Id is not available
+    if (!participantOwnPublicId) {
+      await utils.convos.getConvo.refetch({
+        convoPublicId: convoId,
+        orgShortcode
+      });
+    }
+  }, [convoId, orgShortcode, participantOwnPublicId, utils.convos.getConvo]);
 
   if (convoError && convoError.data?.code === 'NOT_FOUND') {
     return <ConvoNotFound />;


### PR DESCRIPTION
## What does this PR do?

When a convo is received in a space own participant id is not defined, it breaks styling while replying to unassigned convos.
This PR revalidates cache on reply if the id is not defined, fixing the issue

Fixes ENG-157

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Tested my code in a local environment
- [ ] Commented on my code in hard-to-understand areas
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the UnInbox Docs if changes were necessary
