### PR TITLE
fix: add mock incoming email script and fix the reply formatting bug

### DIFF
--- a/apps/mail-bridge/package.json
+++ b/apps/mail-bridge/package.json
@@ -7,7 +7,8 @@
     "dev": "tsx watch --clear-screen=false --import ./tracing.ts app.ts",
     "start": "node --import ./.output/tracing.js .output/app.js",
     "build": "tsup",
-    "check": "tsc --noEmit"
+    "check": "tsc --noEmit",
+    "mock:incoming-mail": "tsx ./scripts/mock-incoming.ts"
   },
   "exports": {
     "./trpc": {
@@ -41,6 +42,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@clack/prompts": "^0.7.0",
     "@types/dompurify": "^3.0.5",
     "@types/jsdom": "^21.1.7",
     "@types/mailparser": "^3.4.4",

--- a/apps/mail-bridge/scripts/email-templates.ts
+++ b/apps/mail-bridge/scripts/email-templates.ts
@@ -1,0 +1,55 @@
+import { nanoid } from 'nanoid';
+
+export const testEmail = ({ from, to }: { from: string; to: string }) =>
+  `
+X-Postal-Spam: no
+X-Postal-Spam-Threshold: 5.0
+X-Postal-Spam-Score: -0.1
+X-Postal-Threat: no
+Received: from zero.e.uninbox.com (zero.e.uninbox.com [5.161.244.126]) by zero.e.uninbox.dev with SMTP; Fri, 16 Aug 2024 12:11:19 -0000
+Resent-Sender: svc1si@unrp.uninbox.com
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+	d=uninbox.com;
+	s=unplatform-ZqqqgePA; t=1723810279;
+	bh=jGTLdTi+Nu+6d2Vfh9z99cMVoICgU6gc5Q9wnRwXOh8=;
+	h=date:from:sender:to:message-id:subject:mime-version:content-type:content-transfer-encoding;
+	b=JzYNWFTFigG8gHZrk6tr4gRiv/LW8M7P7Uy0hyL3RILQNm8mGcw4eFlrm04zIa3T/tkSdL5q
+	Fu5ncLMjULJ4nDk7jPUT0O2MUc7LqW0SSDQJFU/G35ne0x2//QHMi6Y5OC0HEvJ/nOK7ReQF
+	Yjgv5g+W+NJf6eDn0NvmjNdq/ZE=
+X-Postal-MsgID: fJ077hTPCLaYaRzp
+Received: from api (2a00:20:6089:11a1:9038:24ab:ce50:b528 [2a00:20:6089:11a1:9038:24ab:ce50:b528]) by zero.e.uninbox.com with HTTP; Fri, 16 Aug 2024 12:10:24 +0000
+Date: Fri, 16 Aug 2024 12:10:24 +0000
+From: ${from}
+Sender: ${from}
+To: ${to}
+Message-ID: <${nanoid(16)}@rp.zero.e.uninbox.com>
+Subject: Mock email for ${to}
+Mime-Version: 1.0
+Content-Type: multipart/mixed;
+ boundary="--==_mimepart_66bf41b0450df_9e498410621";
+ charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+
+----==_mimepart_66bf41b0450df_9e498410621
+Content-Type: multipart/alternative;
+ boundary="--==_mimepart_66bf41b044f79_9e4984105b3"
+Content-Transfer-Encoding: 7bit
+
+
+----==_mimepart_66bf41b044f79_9e4984105b3
+Content-Type: text/plain;
+ charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+This is a test email
+----==_mimepart_66bf41b044f79_9e4984105b3
+Content-Type: text/html;
+ charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+<p>This is a test email</p>
+----==_mimepart_66bf41b044f79_9e4984105b3--
+
+----==_mimepart_66bf41b0450df_9e498410621--
+`.trim();

--- a/apps/mail-bridge/scripts/mock-incoming.ts
+++ b/apps/mail-bridge/scripts/mock-incoming.ts
@@ -1,0 +1,107 @@
+import { cancel, group, intro, outro, text } from '@clack/prompts';
+import { mailProcessorQueue } from '../queue/mail-processor';
+import { typeIdValidator } from '@u22n/utils/typeid';
+import { testEmail } from './email-templates';
+import { nanoid } from 'nanoid';
+import { z } from 'zod';
+
+intro('Mock Incoming Mail');
+
+const params = await group(
+  {
+    orgId: () =>
+      text({
+        message: 'Enter Postal Org Id',
+        initialValue: '0',
+        validate: (value) => {
+          if (!z.coerce.number().safeParse(value).success) {
+            return 'OrgId must be a number';
+          }
+        }
+      }),
+    mailserverId: () =>
+      text({
+        message: 'Enter your Mailserver Id',
+        initialValue: 'root',
+        validate: (value) => {
+          if (
+            !z
+              .enum(['root', 'fwd'])
+              .or(typeIdValidator('postalServers'))
+              .safeParse(value).success
+          ) {
+            return 'MailserverId must be either root, fwd or a valid postalServerId';
+          }
+        }
+      })
+  },
+  {
+    onCancel: () => {
+      cancel('Cancelled');
+      process.exit(0);
+    }
+  }
+);
+
+const message = await group(
+  {
+    rcpt_to: () =>
+      text({
+        message: 'Enter the recipient email address',
+        validate: (value) => {
+          if (!z.string().includes('@').safeParse(value).success) {
+            return 'Recipient email is not valid';
+          }
+        }
+      }),
+    from: () =>
+      text({
+        message: 'Enter the sender email address',
+        initialValue: 'mock@uninbox.local',
+        validate: (value) => {
+          if (!z.string().email().safeParse(value).success) {
+            return 'Sender email is not valid';
+          }
+        }
+      }),
+    rawMessage: () =>
+      text({
+        message: 'Enter raw email in RFC822 format',
+        placeholder: '(Skip to use test email)',
+        initialValue: ''
+      })
+  },
+  {
+    onCancel: () => {
+      cancel('Cancelled');
+      process.exit(0);
+    }
+  }
+);
+
+const encodedEmail = Buffer.from(
+  message.rawMessage ||
+    testEmail({
+      from: message.from,
+      to: message.rcpt_to
+    })
+).toString('base64');
+
+await mailProcessorQueue.add(`mock incoming mail ${nanoid(6)}`, {
+  params: {
+    orgId: Number(params.orgId),
+    // @ts-expect-error, not important to type properly
+    mailserverId: params.mailserverId
+  },
+  rawMessage: {
+    id: Math.floor(Math.random() * 1000),
+    base64: true,
+    size: encodedEmail.length,
+    mail_from: message.from,
+    rcpt_to: message.rcpt_to,
+    message: encodedEmail
+  }
+});
+
+outro('Mock incoming mail added to queue');
+process.exit(0);

--- a/apps/web/src/app/[orgShortcode]/convo/[convoId]/_components/convo-views.tsx
+++ b/apps/web/src/app/[orgShortcode]/convo/[convoId]/_components/convo-views.tsx
@@ -83,7 +83,7 @@ export function ConvoView({ convoId }: { convoId: TypeId<'convos'> }) {
     virtuosoRef.current?.scrollToIndex({ index: 'LAST' });
     // Refresh the convo data if own public Id is not available
     if (!participantOwnPublicId) {
-      await utils.convos.getConvo.refetch({
+      await utils.convos.getConvo.invalidate({
         convoPublicId: convoId,
         orgShortcode
       });

--- a/apps/web/src/app/[orgShortcode]/convo/[convoId]/_components/messages-panel.tsx
+++ b/apps/web/src/app/[orgShortcode]/convo/[convoId]/_components/messages-panel.tsx
@@ -429,7 +429,9 @@ const MessageItem = memo(
       </div>
     );
   },
-  (prev, curr) => prev.message.publicId === curr.message.publicId
+  (prev, curr) =>
+    prev.message.publicId === curr.message.publicId &&
+    prev.participantOwnPublicId === curr.participantOwnPublicId
 );
 
 const emptyMessage = `<span class="text-base-11 text-sm">THIS MESSAGE CONTAINS NO VALID TEXT CONTENT</span>`;

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "ee:dev:r": "infisical run --env=remote -- turbo run ee:dev",
     "ee:check": "infisical run --env=remote -- turbo run ee:check",
     "ee:build:all": "dotenv -e .env.local -- turbo run ee:build --cache-dir=.turbo",
+    "mock:incoming-mail": "dotenv -e .env.local -- pnpm --dir apps/mail-bridge mock:incoming-mail",
     "prepare": "husky"
   },
   "keywords": [],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
         specifier: ^3.23.8
         version: 3.23.8
     devDependencies:
+      '@clack/prompts':
+        specifier: ^0.7.0
+        version: 0.7.0
       '@types/dompurify':
         specifier: ^3.0.5
         version: 3.0.5
@@ -1209,6 +1212,14 @@ packages:
 
   '@calcom/embed-snippet@1.3.0':
     resolution: {integrity: sha512-g/JnC02VpDHIDLdRWbrh3/L2xLTTph46zojeH6y7O2GXAqQIDtCDOqakmng2zhvoLHt+cs7KuiiN4a/r+CswKg==}
+
+  '@clack/core@0.3.4':
+    resolution: {integrity: sha512-H4hxZDXgHtWTwV3RAVenqcC4VbJZNegbBjlPvzOzCouXtS2y3sDvlO3IsbrPNWuLWPPlYVYPghQdSF64683Ldw==}
+
+  '@clack/prompts@0.7.0':
+    resolution: {integrity: sha512-0MhX9/B4iL6Re04jPrttDm+BsP8y6mS7byuv0BvXgdXhbV5PdlsHt55dvNsuBCPZ7xq1oTAOOuotR9NFbQyMSA==}
+    bundledDependencies:
+      - is-unicode-supported
 
   '@colors/colors@1.6.0':
     resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
@@ -6617,6 +6628,9 @@ packages:
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
 
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -7841,6 +7855,17 @@ snapshots:
   '@calcom/embed-snippet@1.3.0':
     dependencies:
       '@calcom/embed-core': 1.5.0
+
+  '@clack/core@0.3.4':
+    dependencies:
+      picocolors: 1.0.1
+      sisteransi: 1.0.5
+
+  '@clack/prompts@0.7.0':
+    dependencies:
+      '@clack/core': 0.3.4
+      picocolors: 1.0.1
+      sisteransi: 1.0.5
 
   '@colors/colors@1.6.0': {}
 
@@ -13359,6 +13384,8 @@ snapshots:
   simple-swizzle@0.2.2:
     dependencies:
       is-arrayish: 0.3.2
+
+  sisteransi@1.0.5: {}
 
   slash@3.0.0: {}
 


### PR DESCRIPTION
## What does this PR do?

- Added a script to easily mock incoming postal emails
- Fix the reply rendering issue which stayed in #727

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Tested my code in a local environment
- [ ] Commented on my code in hard-to-understand areas
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the UnInbox Docs if changes were necessary
