### PR TITLE
fix: remove convo from selection if deleted

### DIFF
--- a/apps/web/src/app/[orgShortcode]/convo/utils.ts
+++ b/apps/web/src/app/[orgShortcode]/convo/utils.ts
@@ -2,8 +2,10 @@ import { platform, type RouterOutputs } from '@/src/lib/trpc';
 import { type InfiniteData } from '@tanstack/react-query';
 import { useOrgShortcode } from '@/src/hooks/use-params';
 import { type TypeId } from '@u22n/utils/typeid';
+import { convoListSelection } from './atoms';
 import { ms } from '@u22n/utils/ms';
 import { useCallback } from 'react';
+import { useSetAtom } from 'jotai';
 import { produce } from 'immer';
 
 type GetSpacesConvo = RouterOutputs['spaces']['getSpaceConvos'];
@@ -148,6 +150,7 @@ const deleteConvoFromInfiniteData = (
 export function useDeleteConvo$Cache() {
   const orgShortcode = useOrgShortcode();
   const utils = platform.useUtils();
+  const setSelection = useSetAtom(convoListSelection);
 
   return useCallback(
     async ({
@@ -207,13 +210,16 @@ export function useDeleteConvo$Cache() {
           }
         })
       );
+
+      setSelection((prev) => prev.filter((convo) => !convos.includes(convo)));
     },
     [
-      orgShortcode,
+      setSelection,
       utils.convos.getConvo,
-      utils.spaces.getSpaceConvos,
       utils.convos.getOrgMemberSpecificConvo,
-      utils.convos.entries.getConvoEntries
+      utils.convos.entries.getConvoEntries,
+      utils.spaces.getSpaceConvos,
+      orgShortcode
     ]
   );
 }


### PR DESCRIPTION
## What does this PR do?

When multiple convos are selected, deleting a single convo doesn't remove that convo from selection list which leads to error while deleting all others in multi select.

So we remove the deleted convos from selection.

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Tested my code in a local environment
- [ ] Commented on my code in hard-to-understand areas
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the UnInbox Docs if changes were necessary
