### PR TITLE
fix: don't show avatar plus hover card if there are no other users

### DIFF
--- a/apps/web/src/components/avatar-plus.tsx
+++ b/apps/web/src/components/avatar-plus.tsx
@@ -27,6 +27,21 @@ export const AvatarPlus = memo(function AvatarPlus({
   if (!primary) {
     return null;
   }
+
+  if (rest.length === 0) {
+    return (
+      <div className="relative h-fit w-fit scale-100 overflow-visible">
+        <Avatar
+          avatarProfilePublicId={primary.avatarProfilePublicId}
+          avatarTimestamp={primary.avatarTimestamp}
+          name={primary.name}
+          size={size}
+          hideTooltip={true}
+        />
+      </div>
+    );
+  }
+
   return (
     <div className="relative h-fit w-fit scale-100 overflow-visible">
       <HoverCard>


### PR DESCRIPTION
## What does this PR do?

Don't show hover card when there are no extra participants in avatar plus hover card

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Tested my code in a local environment
- [ ] Commented on my code in hard-to-understand areas
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the UnInbox Docs if changes were necessary
