### PR TITLE
fix: use files in mock-incoming

### DIFF
--- a/apps/mail-bridge/queue/mail-processor.ts
+++ b/apps/mail-bridge/queue/mail-processor.ts
@@ -1031,8 +1031,8 @@ export const worker = createWorker<MailProcessorJobData>(
         console.error(e);
         void discord.info(
           e instanceof Error
-            ? `${e.message} \n${e.stack}`
-            : 'Unknown Error, Check Logs'
+            ? e.message
+            : 'Unknown Error in Mail Processor, Check Logs'
         );
         span?.recordException(e as Error);
         // Throw the error to be caught by the worker, and moving to failed jobs


### PR DESCRIPTION
## What does this PR do?

Make incoming email mock use file path for raw emails

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Tested my code in a local environment
- [ ] Commented on my code in hard-to-understand areas
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the UnInbox Docs if changes were necessary
