### PR TITLE
fix: form schema for smtp port

### DIFF
--- a/apps/web/src/app/[orgShortcode]/settings/org/mail/addresses/add/page.tsx
+++ b/apps/web/src/app/[orgShortcode]/settings/org/mail/addresses/add/page.tsx
@@ -608,7 +608,11 @@ const externalAddressFormSchema = z.object({
   sendName: z.string().min(1, 'You must enter a send name').max(64),
   smtp: z.object({
     host: z.string().min(3).includes('.'),
-    port: z.number().min(1).max(65535),
+    port: z.coerce
+      .number({ invalid_type_error: 'Port Must be a number' })
+      .int()
+      .min(1)
+      .max(65535),
     username: z.string().min(1),
     password: z.string().min(1),
     encryption: z.enum(['none', 'ssl', 'tls', 'starttls']),
@@ -797,6 +801,7 @@ function AddExternalEmail() {
                     <FormControl>
                       <Input
                         fullWidth
+                        inputMode="numeric"
                         label="SMTP Port"
                         {...field}
                       />


### PR DESCRIPTION
## What does this PR do?

Fix form schema to allow smtp port to be a number coerced from string.

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Tested my code in a local environment
- [ ] Commented on my code in hard-to-understand areas
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the UnInbox Docs if changes were necessary
