### PR TITLE
feat: fix emails while sending with external credentials

### DIFF
--- a/apps/platform/trpc/routers/orgRouter/mail/emailIdentityRouter.ts
+++ b/apps/platform/trpc/routers/orgRouter/mail/emailIdentityRouter.ts
@@ -543,17 +543,29 @@ export const emailIdentityRouter = router({
       const authorizedSpaceIds: number[] = [];
 
       if (input.spaceShortcode) {
-        const spaceQueryResponse = await db.query.spaces.findFirst({
-          where: and(
-            eq(spaces.orgId, orgId),
-            eq(spaces.shortcode, input.spaceShortcode)
-          ),
-          columns: {
-            id: true
+        if (input.spaceShortcode === 'personal') {
+          const personalSpace = await db.query.orgMembers.findFirst({
+            where: eq(orgMembers.id, orgMemberId),
+            columns: {
+              personalSpaceId: true
+            }
+          });
+          if (personalSpace?.personalSpaceId) {
+            authorizedSpaceIds.push(personalSpace.personalSpaceId);
           }
-        });
-        if (spaceQueryResponse?.id) {
-          authorizedSpaceIds.push(spaceQueryResponse.id);
+        } else {
+          const spaceQueryResponse = await db.query.spaces.findFirst({
+            where: and(
+              eq(spaces.orgId, orgId),
+              eq(spaces.shortcode, input.spaceShortcode)
+            ),
+            columns: {
+              id: true
+            }
+          });
+          if (spaceQueryResponse?.id) {
+            authorizedSpaceIds.push(spaceQueryResponse.id);
+          }
         }
       }
 

--- a/apps/web/src/app/[orgShortcode]/convo/_components/create-convo-form.tsx
+++ b/apps/web/src/app/[orgShortcode]/convo/_components/create-convo-form.tsx
@@ -218,7 +218,7 @@ export default function CreateConvoForm({
     });
 
   const [selectedSpace, setSelectedSpace] = useState<string | null>(
-    ['all', 'personal', null].includes(spaceShortcode) ? null : spaceShortcode
+    ['all', null].includes(spaceShortcode) ? null : spaceShortcode
   );
   const { data: userEmailIdentities, isLoading: emailIdentitiesLoading } =
     platform.org.mail.emailIdentities.getUserEmailIdentities.useQuery(
@@ -491,6 +491,19 @@ export default function CreateConvoForm({
       throw new Error('Please select a space for the conversation.');
     }
 
+    const resolvedSpaceShortcode =
+      selectedSpace === 'personal'
+        ? spaces?.find(
+            (space) => space.publicId === spacesResponse?.personalSpaceId
+          )?.shortcode
+        : selectedSpace;
+
+    if (!resolvedSpaceShortcode) {
+      throw new Error(
+        'Failed to resolve space shortcode. Contact support if this persists.'
+      );
+    }
+
     return createConvoFn({
       firstMessageType: type,
       topic,
@@ -503,7 +516,7 @@ export default function CreateConvoForm({
       message: editorText,
       attachments: getTrpcUploadFormat(),
       orgShortcode,
-      spaceShortcode: selectedSpace
+      spaceShortcode: resolvedSpaceShortcode
     });
   }
 
@@ -692,7 +705,11 @@ export default function CreateConvoForm({
             {spaces?.map((space) => (
               <SelectItem
                 key={space.shortcode}
-                value={space.shortcode}>
+                value={
+                  space.publicId === spacesResponse?.personalSpaceId
+                    ? 'personal'
+                    : space.shortcode
+                }>
                 {space.name}
               </SelectItem>
             ))}


### PR DESCRIPTION
## What does this PR do?

- Send emails in proper format while sending over external SMTP
- Fix `org.mail.emailIdentities.getUserEmailIdentities` endpoint while `spaceShortcode` is `personal`
- Automatically translate own space to `personal` and vice versa


## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Tested my code in a local environment
- [ ] Commented on my code in hard-to-understand areas
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the UnInbox Docs if changes were necessary
