### PR TITLE
fix: Update correct space when creating a convo

### DIFF
--- a/apps/web/src/app/[orgShortcode]/convo/_components/create-convo-form.tsx
+++ b/apps/web/src/app/[orgShortcode]/convo/_components/create-convo-form.tsx
@@ -539,7 +539,7 @@ export default function CreateConvoForm({
     onSuccess: async (data) => {
       await addConvo({
         convoPublicId: data.publicId,
-        spaceShortcode: spaceShortcode ?? 'personal'
+        spaceShortcode: selectedSpace ?? 'personal'
       });
       resetDraft();
       setNewPanelOpen(false);

--- a/apps/web/src/app/[orgShortcode]/convo/utils.ts
+++ b/apps/web/src/app/[orgShortcode]/convo/utils.ts
@@ -128,6 +128,10 @@ export function useAddSingleConvo$Cache() {
                 }
               });
             }
+            // If the last page was empty, remove the cursor
+            if (draft.pages.at(-1)?.cursor === null && pages.at(-1)?.cursor) {
+              pages.at(-1)!.cursor = null;
+            }
             draft.pages = pages;
           });
         });


### PR DESCRIPTION
## What does this PR do?

Updates the correct space cache when creating a new convo
Fixes ENG-164

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Tested my code in a local environment
- [ ] Commented on my code in hard-to-understand areas
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the UnInbox Docs if changes were necessary
