### PR TITLE
fix: worker DNS check for SPF

### DIFF
--- a/apps/worker/env.ts
+++ b/apps/worker/env.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 
 export const env = createEnv({
   server: {
+    PRIMARY_DOMAIN: z.string(),
     PLATFORM_URL: z.string().url(),
     DB_REDIS_CONNECTION_STRING: z.string().min(1),
     WORKER_ACCESS_KEY: z.string().min(32),

--- a/apps/worker/functions/check-dns.ts
+++ b/apps/worker/functions/check-dns.ts
@@ -23,7 +23,7 @@ export async function checkDns(publicId: TypeId<'domains'>) {
         value: domainInfo.verificationToken
       },
       spf: {
-        includes: `_spf.${domainInfo.postalHost}`
+        includes: [`_spf.${env.PRIMARY_DOMAIN}`]
       },
       dkim: {
         key: domainInfo.dkimKey,

--- a/packages/utils/dns/verifier.ts
+++ b/packages/utils/dns/verifier.ts
@@ -21,7 +21,7 @@ type ExpectedDnsRecords = {
     priority: number;
   };
   spf: {
-    includes: string;
+    includes: string[];
   };
   dkim: {
     key: string | null;
@@ -72,7 +72,8 @@ export async function dnsVerifier({ rootDomain, expected }: DnsVerifierInput) {
       spfTxtRecords.data.find((_) => _.startsWith('v=spf1')) ?? ''
     );
     results.spf.valid =
-      !!spfRecords && spfRecords.includes.includes(expected.spf.includes);
+      !!spfRecords &&
+      expected.spf.includes.some((_) => spfRecords.includes.includes(_));
     results.spf.current = spfRecords;
   }
 


### PR DESCRIPTION
## What does this PR do?

The DNS check updates records everytime as SPF check in worker was invalid. This fixes the check for spf.

Fixes # (issue)

_If there is not an issue for this, please create one first. This is used to tracking purposes and also helps use understand why this PR exists_

<!-- If there isn't an issue for this PR, please re-review our Contributing Guide and create an issue -->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Tested my code in a local environment
- [ ] Commented on my code in hard-to-understand areas
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the UnInbox Docs if changes were necessary
