### PR TITLE
feat: billing system overhaul

### DIFF
--- a/apps/platform/trpc/routers/orgRouter/setup/billingRouter.ts
+++ b/apps/platform/trpc/routers/orgRouter/setup/billingRouter.ts
@@ -30,34 +30,22 @@ export const billingRouter = router({
           and(eq(orgMembers.orgId, orgId), eq(orgMembers.status, 'active'))
         );
 
+      const dates = orgBillingQuery
+        ? await billingTrpcClient.stripe.subscriptions.getSubscriptionDates.query(
+            {
+              orgId
+            }
+          )
+        : null;
+
       return {
         totalUsers: activeOrgMembersCount[0]?.count,
         currentPlan: orgPlan,
-        currentPeriod: orgPeriod
+        currentPeriod: orgPeriod,
+        dates
       };
     }),
-  getOrgStripePortalLink: eeProcedure
-    .unstable_concat(orgAdminProcedure)
-    .query(async ({ ctx }) => {
-      const { org } = ctx;
-      const orgId = org.id;
-
-      const orgPortalLink =
-        await billingTrpcClient.stripe.links.getPortalLink.query({
-          orgId: orgId
-        });
-
-      if (!orgPortalLink.link) {
-        throw new TRPCError({
-          code: 'FORBIDDEN',
-          message: 'Org not subscribed to a plan'
-        });
-      }
-      return {
-        portalLink: orgPortalLink.link
-      };
-    }),
-  getOrgSubscriptionPaymentLink: eeProcedure
+  createCheckoutSession: eeProcedure
     .unstable_concat(orgAdminProcedure)
     .input(
       z.object({
@@ -76,6 +64,7 @@ export const billingRouter = router({
           id: true
         }
       });
+
       if (orgSubscriptionQuery?.id) {
         throw new TRPCError({
           code: 'FORBIDDEN',
@@ -93,24 +82,38 @@ export const billingRouter = router({
       const activeOrgMembersCount = Number(
         activeOrgMembersCountResponse[0]?.count ?? '0'
       );
-      const orgSubLink =
-        await billingTrpcClient.stripe.links.createSubscriptionPaymentLink.mutate(
-          {
-            orgId: orgId,
-            plan: plan,
-            period: period,
-            totalOrgUsers: activeOrgMembersCount
-          }
-        );
+      const checkoutSession =
+        await billingTrpcClient.stripe.links.createCheckoutSession.mutate({
+          orgId: orgId,
+          plan: plan,
+          period: period,
+          totalOrgUsers: activeOrgMembersCount
+        });
 
-      if (!orgSubLink.link) {
+      return {
+        checkoutSessionId: checkoutSession.id,
+        checkoutSessionClientSecret: checkoutSession.clientSecret
+      };
+    }),
+  getOrgStripePortalLink: eeProcedure
+    .unstable_concat(orgAdminProcedure)
+    .mutation(async ({ ctx }) => {
+      const { org } = ctx;
+      const orgId = org.id;
+
+      const orgPortalLink =
+        await billingTrpcClient.stripe.links.getPortalLink.query({
+          orgId: orgId
+        });
+
+      if (!orgPortalLink.link) {
         throw new TRPCError({
           code: 'FORBIDDEN',
           message: 'Org not subscribed to a plan'
         });
       }
       return {
-        subLink: orgSubLink.link
+        portalLink: orgPortalLink.link
       };
     }),
   isPro: eeProcedure.query(async ({ ctx }) => {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -40,6 +40,8 @@
     "@radix-ui/react-toggle-group": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.1.2",
     "@simplewebauthn/browser": "^10.0.0",
+    "@stripe/react-stripe-js": "^2.8.0",
+    "@stripe/stripe-js": "^4.3.0",
     "@t3-oss/env-core": "^0.11.0",
     "@tailwindcss/typography": "^0.5.14",
     "@tanstack/react-query": "^5.52.1",

--- a/apps/web/src/app/[orgShortcode]/settings/org/setup/billing/page.tsx
+++ b/apps/web/src/app/[orgShortcode]/settings/org/setup/billing/page.tsx
@@ -8,8 +8,6 @@ import { useOrgShortcode } from '@/src/hooks/use-params';
 import { useEffect, useState } from 'react';
 import CalEmbed from '@calcom/embed-react';
 import { platform } from '@/src/lib/trpc';
-import { cn } from '@/src/lib/utils';
-import Link from 'next/link';
 
 export default function Page() {
   const orgShortcode = useOrgShortcode();
@@ -18,13 +16,8 @@ export default function Page() {
       orgShortcode
     });
 
-  const { data: portalLink } =
-    platform.org.setup.billing.getOrgStripePortalLink.useQuery(
-      { orgShortcode },
-      {
-        enabled: data?.currentPlan === 'pro'
-      }
-    );
+  const { mutateAsync: createPortalLink, isPending: isLoadingPortalLink } =
+    platform.org.setup.billing.getOrgStripePortalLink.useMutation();
 
   const [showPlan, setShowPlans] = useState(false);
 
@@ -78,18 +71,47 @@ export default function Page() {
           )}
           {showPlan && <PricingTable />}
           {data.currentPlan === 'pro' && (
-            <Button
-              className={cn(
-                'w-fit',
-                !portalLink && 'pointer-events-none opacity-75'
-              )}
-              asChild>
-              <Link
-                href={portalLink?.portalLink ?? '#'}
-                target="_blank">
+            <div className="flex flex-col gap-2">
+              <Button
+                className="w-fit"
+                loading={isLoadingPortalLink}
+                onClick={async () => {
+                  const { portalLink } = await createPortalLink({
+                    orgShortcode
+                  });
+                  window.open(portalLink, '_blank');
+                }}>
                 Manage Your Subscription
-              </Link>
-            </Button>
+              </Button>
+
+              <div className="flex flex-col gap-2 py-2">
+                {data.dates?.start_date ? (
+                  <div>
+                    <span>Subscription started on </span>
+                    <span className="font-semibold">
+                      {new Date(
+                        data.dates.start_date * 1000
+                      ).toLocaleDateString()}
+                    </span>
+                  </div>
+                ) : null}
+
+                <div>
+                  {data.dates?.cancel_at_period_end ? (
+                    <span>Pending cancelation on </span>
+                  ) : (
+                    <span>Subscription renews on </span>
+                  )}
+                  <span className="font-semibold">
+                    {data.dates?.current_period_end
+                      ? new Date(
+                          data.dates?.current_period_end * 1000
+                        ).toLocaleDateString()
+                      : 'End of Current billing cycle'}
+                  </span>
+                </div>
+              </div>
+            </div>
           )}
           {data.currentPlan === 'pro' && (
             <div className="my-4 flex w-full flex-1 flex-col gap-2">

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -27,7 +27,8 @@ if (!IS_BROWSER) {
     'EE_ENABLED',
     'POSTHOG_KEY',
     'POSTHOG_ENABLED',
-    'APP_VERSION'
+    'APP_VERSION',
+    'BILLING_STRIPE_PUBLISHABLE_KEY'
   ];
 
   PUBLIC_ENV_LIST.forEach((key) => {
@@ -48,6 +49,7 @@ export const env = createEnv({
     NEXT_PUBLIC_REALTIME_PORT: z.coerce.number().optional(),
     NEXT_PUBLIC_TURNSTILE_SITE_KEY: z.string().optional(),
     NEXT_PUBLIC_EE_ENABLED: z.enum(['true', 'false']),
+    NEXT_PUBLIC_BILLING_STRIPE_PUBLISHABLE_KEY: z.string().optional(),
     NEXT_PUBLIC_APP_VERSION: z.string().default('development'),
     NEXT_PUBLIC_POSTHOG_ENABLED: z.enum(['true', 'false']).default('false'),
     NEXT_PUBLIC_POSTHOG_KEY: IS_POSTHOG_ENABLED

--- a/ee/apps/billing/app.ts
+++ b/ee/apps/billing/app.ts
@@ -5,7 +5,8 @@ import {
   setupHealthReporting,
   setupHonoListener,
   setupRuntime,
-  setupTrpcHandler
+  setupTrpcHandler,
+  setupRouteLogger
 } from '@u22n/hono';
 import { stripeWebhookMiddleware } from './middlewares';
 import { validateLicense } from './validateLicenseKey';
@@ -19,6 +20,7 @@ import { env } from './env';
 await validateLicense();
 
 const app = createHonoApp<Ctx>();
+setupRouteLogger(app, env.NODE_ENV === 'development');
 setupCors(app, { origin: env.WEBAPP_URL });
 setupHealthReporting(app, { service: 'Billing' });
 setupErrorHandlers(app);

--- a/ee/apps/billing/scripts/sync-stripe-db.ts
+++ b/ee/apps/billing/scripts/sync-stripe-db.ts
@@ -1,0 +1,114 @@
+import {
+  createOrUpdateBillingRecords,
+  resolvePriceItem,
+  validateMetadata
+} from '../routes/stripe';
+import { orgBilling, orgMembers } from '@u22n/database/schema';
+import { and, eq, inArray, sql } from '@u22n/database/orm';
+import { stripeSdk } from '../stripe';
+import { db } from '@u22n/database';
+
+const confirm = process.argv.includes('--confirm');
+
+const subscriptions = await stripeSdk.subscriptions.list();
+
+const dbOrgIds = (
+  await db.query.orgBilling.findMany({
+    columns: { orgId: true }
+  })
+).map(({ orgId }) => orgId);
+
+const listOfUpdatedOrgs: number[] = [];
+
+if (!confirm) {
+  console.info('Doing a dry run, not updating any data');
+}
+
+for (const subscription of subscriptions.data) {
+  console.info('Processing subscription', subscription.id);
+
+  const { orgId, totalUsers } = validateMetadata(subscription.metadata);
+  if (listOfUpdatedOrgs.includes(orgId)) {
+    console.info('Duplicate subscription, skipping', {
+      id: subscription.id,
+      orgId
+    });
+    continue;
+  }
+  listOfUpdatedOrgs.push(orgId);
+
+  const activeOrgMembersCount = await db
+    .select({ count: sql<string>`count(*)` })
+    .from(orgMembers)
+    .where(and(eq(orgMembers.orgId, orgId), eq(orgMembers.status, 'active')));
+
+  const totalOrgUsers = Number(activeOrgMembersCount[0]?.count ?? '1');
+
+  if (totalOrgUsers !== totalUsers) {
+    console.info(
+      'Total users mismatch between stripe and database, will update stripe',
+      {
+        subscriptionId: subscription.id,
+        orgId,
+        totalOrgUsers,
+        totalUsers
+      }
+    );
+  }
+
+  if (confirm) {
+    // Update the subscription with the new metadata, removing the old metadata
+    await stripeSdk.subscriptions.update(subscription.id, {
+      description: `Total users: ${totalOrgUsers}`,
+      items: [
+        {
+          id: subscription.items.data[0]?.id,
+          quantity: totalOrgUsers
+        }
+      ],
+      proration_behavior: 'always_invoice',
+      metadata: {
+        orgId,
+        totalUsers: totalOrgUsers
+      }
+    });
+  }
+
+  const priceId = subscription.items.data[0]?.price.id;
+  if (!priceId) {
+    console.info('No price id found', {
+      subscription
+    });
+    continue;
+  }
+  const price = resolvePriceItem(priceId);
+
+  if (confirm) {
+    await createOrUpdateBillingRecords({
+      orgId,
+      price,
+      stripeCustomerId: subscription.customer as string,
+      stripeSubscriptionId: subscription.id,
+      active: subscription.status === 'active'
+    });
+  }
+}
+
+const orphanDbEntries = dbOrgIds.filter(
+  (id) => !listOfUpdatedOrgs.includes(id)
+);
+
+if (orphanDbEntries.length > 0) {
+  console.info(
+    `Found ${orphanDbEntries.length} database entries which don't have a subscription attached to them`,
+    orphanDbEntries
+  );
+
+  console.info('Deleting orphan database entries');
+
+  if (confirm) {
+    await db
+      .delete(orgBilling)
+      .where(inArray(orgBilling.orgId, orphanDbEntries));
+  }
+}

--- a/ee/apps/billing/trpc/routers/stripeLinksRouter.ts
+++ b/ee/apps/billing/trpc/routers/stripeLinksRouter.ts
@@ -1,11 +1,12 @@
 import { stripePlans, stripeBillingPeriods, stripeSdk } from '../../stripe';
 import { router, protectedProcedure } from '../trpc';
 import { orgBilling } from '@u22n/database/schema';
+import { TRPCError } from '@trpc/server';
 import { eq } from '@u22n/database/orm';
 import { z } from 'zod';
 
 export const stripeLinksRouter = router({
-  createSubscriptionPaymentLink: protectedProcedure
+  createCheckoutSession: protectedProcedure
     .input(
       z.object({
         orgId: z.number().min(1),
@@ -17,35 +18,35 @@ export const stripeLinksRouter = router({
     .mutation(async ({ ctx, input }) => {
       const { stripe } = ctx;
       const { orgId, totalOrgUsers } = input;
-
       const planPriceId = stripe.plans[input.plan][input.period];
       const subscriptionDescription = `Total users: ${totalOrgUsers}`;
 
-      const subscribeToPlan = await stripeSdk.paymentLinks.create({
-        metadata: {
-          orgId
-        },
-        line_items: [
-          {
-            price: planPriceId,
-            quantity: totalOrgUsers
-          }
-        ],
+      const checkoutSession = await stripeSdk.checkout.sessions.create({
+        ui_mode: 'embedded',
+        metadata: { orgId },
+        line_items: [{ price: planPriceId, quantity: totalOrgUsers }],
         subscription_data: {
           description: subscriptionDescription,
           metadata: {
             orgId,
-            product: 'subscription',
-            plan: input.plan,
-            period: input.period,
             totalUsers: input.totalOrgUsers
           }
         },
-        allow_promotion_codes: true
+        allow_promotion_codes: true,
+        mode: 'subscription',
+        redirect_on_completion: 'never'
       });
 
+      if (!checkoutSession.client_secret) {
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Failed to create checkout session'
+        });
+      }
+
       return {
-        link: subscribeToPlan.url
+        id: checkoutSession.id,
+        clientSecret: checkoutSession.client_secret
       };
     }),
   getPortalLink: protectedProcedure
@@ -69,7 +70,7 @@ export const stripeLinksRouter = router({
         throw new Error('No stripe customer id');
 
       const portalLink = await stripeSdk.billingPortal.sessions.create({
-        customer: orgBillingQuery?.stripeCustomerId
+        customer: orgBillingQuery.stripeCustomerId
       });
 
       return {

--- a/ee/apps/billing/trpc/routers/subscriptionsRouter.ts
+++ b/ee/apps/billing/trpc/routers/subscriptionsRouter.ts
@@ -2,9 +2,50 @@ import { orgBilling, orgMembers } from '@u22n/database/schema';
 import { router, protectedProcedure } from '../trpc';
 import { and, eq, sql } from '@u22n/database/orm';
 import { stripeSdk } from '../../stripe';
+import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
 export const subscriptionsRouter = router({
+  getSubscriptionDates: protectedProcedure
+    .input(
+      z.object({
+        orgId: z.number().min(1)
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      const { db } = ctx;
+      const { orgId } = input;
+
+      const orgSubscriptionQuery = await db.query.orgBilling.findFirst({
+        where: eq(orgBilling.orgId, orgId),
+        columns: {
+          id: true,
+          orgId: true,
+          stripeSubscriptionId: true,
+          stripeCustomerId: true,
+          plan: true,
+          period: true
+        }
+      });
+
+      if (!orgSubscriptionQuery?.stripeSubscriptionId) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Org is not subscribed to a plan'
+        });
+      }
+
+      const { start_date, cancel_at_period_end, current_period_end } =
+        await stripeSdk.subscriptions.retrieve(
+          orgSubscriptionQuery.stripeSubscriptionId
+        );
+
+      return {
+        start_date,
+        cancel_at_period_end,
+        current_period_end
+      };
+    }),
   updateOrgUserCount: protectedProcedure
     .input(
       z.object({
@@ -48,7 +89,8 @@ export const subscriptionsRouter = router({
 
         if (
           stripeGetSubscriptionResult &&
-          stripeGetSubscriptionResult.items?.data
+          stripeGetSubscriptionResult.items?.data &&
+          stripeGetSubscriptionResult.status === 'active'
         ) {
           await stripeSdk.subscriptions.update(
             orgSubscriptionQuery.stripeSubscriptionId,
@@ -63,10 +105,6 @@ export const subscriptionsRouter = router({
               proration_behavior: 'always_invoice',
               metadata: {
                 orgId,
-                product: 'subscription',
-                plan: stripeGetSubscriptionResult.metadata.plan ?? 'starter',
-                period:
-                  stripeGetSubscriptionResult.metadata.period ?? 'monthly',
                 totalUsers: totalOrgUsers
               }
             }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -366,6 +366,12 @@ importers:
       '@simplewebauthn/browser':
         specifier: ^10.0.0
         version: 10.0.0
+      '@stripe/react-stripe-js':
+        specifier: ^2.8.0
+        version: 2.8.0(@stripe/stripe-js@4.3.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@stripe/stripe-js':
+        specifier: ^4.3.0
+        version: 4.3.0
       '@t3-oss/env-core':
         specifier: ^0.11.0
         version: 0.11.0(typescript@5.5.4)(zod@3.23.8)
@@ -3377,6 +3383,17 @@ packages:
   '@smithy/util-waiter@3.1.2':
     resolution: {integrity: sha512-4pP0EV3iTsexDx+8PPGAKCQpd/6hsQBaQhqWzU4hqKPHN5epPsxKbvUTIiYIHTxaKt6/kEaqPBpu/ufvfbrRzw==}
     engines: {node: '>=16.0.0'}
+
+  '@stripe/react-stripe-js@2.8.0':
+    resolution: {integrity: sha512-Vf1gNEuBxA9EtxiLghm2ZWmgbADNMJw4HW6eolUu0DON/6mZvWZgk0KHolN0sozNJwYp0i/8hBsDBcBUWcvnbw==}
+    peerDependencies:
+      '@stripe/stripe-js': ^1.44.1 || ^2.0.0 || ^3.0.0 || ^4.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+
+  '@stripe/stripe-js@4.3.0':
+    resolution: {integrity: sha512-bf8MxzzgD3dybtyIJUQSDMqxjEkJfsmj9IdRqDv609Zw08R41O7eoIy0f8KY41u8MbaFOYsn+XGJZtg1xwR2wQ==}
+    engines: {node: '>=12.16'}
 
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
@@ -9527,6 +9544,15 @@ snapshots:
       '@smithy/abort-controller': 3.1.1
       '@smithy/types': 3.3.0
       tslib: 2.7.0
+
+  '@stripe/react-stripe-js@2.8.0(@stripe/stripe-js@4.3.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@stripe/stripe-js': 4.3.0
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@stripe/stripe-js@4.3.0': {}
 
   '@swc/counter@0.1.3': {}
 


### PR DESCRIPTION
## What does this PR do?

Fixes ENG-111
Fixes ENG-126
Fixes ENG-116
Fixes #476

## Changes
- Subscribing to Plans are now done in a embedded Checkout modal without having user to leave UnInbox.
- Handle subscription creation, updates and deletes properly
- Update subscription details when a user deletes their account
- Create a migration script for syncing stripe with `orgBiliing` database
- Change the metadata to only store `orgId` and `totalusers`, as everything else should be determined by stripe price objects

## Important
- We need a new Env variable with name `BILLING_STRIPE_PUBLISHABLE_KEY` to render the stripe modal