### PR TITLE
fix: inline images breaking due to special characters

### DIFF
--- a/apps/platform/trpc/routers/convoRouter/convoRouter.ts
+++ b/apps/platform/trpc/routers/convoRouter/convoRouter.ts
@@ -1223,8 +1223,7 @@ export const convoRouter = router({
             fileName: attachment.fileName,
             type: attachment.type,
             size: attachment.size,
-            createdAt: newConvoEntryTimestamp,
-            inline: true
+            createdAt: newConvoEntryTimestamp
           });
 
           pendingAttachmentsToRemoveFromPending.push(

--- a/apps/storage/proxy/attachment.ts
+++ b/apps/storage/proxy/attachment.ts
@@ -44,7 +44,7 @@ export const attachmentProxy = createHonoApp<Ctx>().get(
 
     if (
       !attachmentQueryResponse ||
-      attachmentQueryResponse.fileName !== filename ||
+      decodeURIComponent(attachmentQueryResponse.fileName) !== filename ||
       attachmentQueryResponse.org.shortcode !== orgShortcode
     ) {
       return c.json(


### PR DESCRIPTION
## What does this PR do?

Fixes ENG-166
Inline images now work even if they have special characters in their names

also fixed the bug where replying with attachments were sent marked as inline so users could not see them

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Tested my code in a local environment
- [ ] Commented on my code in hard-to-understand areas
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the UnInbox Docs if changes were necessary
