### PR TITLE
fix: make filename check work with both encoded and non-encoded name

### DIFF
--- a/apps/storage/proxy/attachment.ts
+++ b/apps/storage/proxy/attachment.ts
@@ -44,8 +44,18 @@ export const attachmentProxy = createHonoApp<Ctx>().get(
 
     if (
       !attachmentQueryResponse ||
-      decodeURIComponent(attachmentQueryResponse.fileName) !== filename ||
       attachmentQueryResponse.org.shortcode !== orgShortcode
+    ) {
+      return c.json(
+        { error: `Attachment ${filename} not found` },
+        { status: 404 }
+      );
+    }
+
+    // Check if the filename is the same as the one in the database both encoded and decoded
+    if (
+      filename !== attachmentQueryResponse.fileName &&
+      filename !== decodeURIComponent(attachmentQueryResponse.fileName)
     ) {
       return c.json(
         { error: `Attachment ${filename} not found` },


### PR DESCRIPTION
## What does this PR do?

Check the filename with both encoded and non-encoded name for match test before sending out the response. It makes sure older names still work

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Tested my code in a local environment
- [ ] Commented on my code in hard-to-understand areas
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the UnInbox Docs if changes were necessary
