### PR TITLE
fix: delete subscription only if the event is a delete event

### DIFF
--- a/ee/apps/billing/scripts/sync-stripe-db.ts
+++ b/ee/apps/billing/scripts/sync-stripe-db.ts
@@ -116,7 +116,8 @@ for (const entry of orgBillingEntries) {
       price,
       stripeCustomerId: subscription.customer as string,
       stripeSubscriptionId: subscription.id,
-      active: subscription.status === 'active'
+      active: subscription.status === 'active',
+      deleteEvent: false
     });
   }
 }


### PR DESCRIPTION
## What does this PR do?

Delete subscription from db only if the event is a delete event to prevent out of order events from deleting db entires

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Tested my code in a local environment
- [ ] Commented on my code in hard-to-understand areas
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the UnInbox Docs if changes were necessary
