### PR TITLE
fix: personal spaces can be made private without a pro plan

### DIFF
--- a/apps/platform/trpc/routers/spaceRouter/spaceSettingsRouter.ts
+++ b/apps/platform/trpc/routers/spaceRouter/spaceSettingsRouter.ts
@@ -1,12 +1,12 @@
+import { iCanHazCallerFactory } from '../orgRouter/iCanHaz/iCanHazRouter';
 import { router, orgProcedure } from '~platform/trpc/trpc';
-import { z } from 'zod';
-
 import { spaceTypeArray } from '@u22n/utils/spaces';
 import { isOrgMemberSpaceMember } from './utils';
 import { spaces } from '@u22n/database/schema';
 import { uiColors } from '@u22n/utils/colors';
 import { eq, and } from '@u22n/database/orm';
 import { TRPCError } from '@trpc/server';
+import { z } from 'zod';
 
 export const spaceSettingsRouter = router({
   getSpacesSettings: orgProcedure
@@ -272,6 +272,34 @@ export const spaceSettingsRouter = router({
         });
       }
 
+      if (
+        spaceMembershipResponse.isPersonalSpace &&
+        input.spaceType === 'open'
+      ) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'You cannot change the type of a personal space to open'
+        });
+      }
+
+      if (
+        !spaceMembershipResponse.isPersonalSpace &&
+        input.spaceType === 'private'
+      ) {
+        const iCanHazCaller = iCanHazCallerFactory(ctx);
+        const canHazSpace = await iCanHazCaller.space({
+          orgShortcode: input.orgShortcode
+        });
+
+        if (input.spaceType === 'private' && !canHazSpace.private) {
+          throw new TRPCError({
+            code: 'FORBIDDEN',
+            message:
+              'You cannot change the type of a space to private on your current plan'
+          });
+        }
+      }
+
       try {
         await db
           .update(spaces)
@@ -288,7 +316,7 @@ export const spaceSettingsRouter = router({
         console.error(error);
         throw new TRPCError({
           code: 'INTERNAL_SERVER_ERROR',
-          message: 'Error while updating Space description'
+          message: 'Error while updating Space type'
         });
       }
 

--- a/apps/platform/trpc/routers/spaceRouter/utils.ts
+++ b/apps/platform/trpc/routers/spaceRouter/utils.ts
@@ -125,6 +125,7 @@ type IsOrgMemberSpaceMemberResponse = {
   role: SpaceMemberRole | null;
   spaceId: number;
   type: SpaceType;
+  isPersonalSpace: boolean;
   permissions: {
     canCreate: boolean;
     canRead: boolean;
@@ -157,7 +158,8 @@ export async function isOrgMemberSpaceMember({
     columns: {
       id: true,
       publicId: true,
-      type: true
+      type: true,
+      personalSpace: true
     },
     with: {
       members: {
@@ -231,6 +233,7 @@ export async function isOrgMemberSpaceMember({
     role: null,
     spaceId: spaceQueryResponse.id,
     type: spaceQueryResponse.type,
+    isPersonalSpace: spaceQueryResponse.personalSpace,
     permissions: {
       canCreate: false,
       canRead: false,

--- a/apps/web/src/app/[orgShortcode]/[spaceShortcode]/settings/page.tsx
+++ b/apps/web/src/app/[orgShortcode]/[spaceShortcode]/settings/page.tsx
@@ -166,14 +166,15 @@ export default function SettingsPage() {
               </div>
             </div>
             <ColorField
-              initialValue={spaceSettings?.settings?.color}
+              initialValue={spaceSettings.settings.color}
               showSaved={setShowSaved}
               isSpaceAdmin={isSpaceAdmin}
             />
             <VisibilityField
-              initialValue={spaceSettings?.settings?.type}
+              initialValue={spaceSettings.settings.type}
               showSaved={setShowSaved}
               isSpaceAdmin={isSpaceAdmin}
+              personalSpace={spaceSettings.settings.personalSpace}
             />
             <Workflows
               showSaved={setShowSaved}
@@ -433,10 +434,12 @@ function ColorField({
 function VisibilityField({
   initialValue,
   showSaved,
+  personalSpace,
   isSpaceAdmin
 }: {
   initialValue: string;
   isSpaceAdmin: boolean;
+  personalSpace: boolean;
   showSaved: (value: boolean) => void;
 }) {
   const orgShortcode = useOrgShortcode();
@@ -483,7 +486,9 @@ function VisibilityField({
           <SelectContent>
             <SelectItem
               value="open"
-              className="hover:bg-base-3 w-full rounded-sm">
+              className="hover:bg-base-3 w-full rounded-sm"
+              // Don't allow changing the visibility of a personal space to open
+              disabled={personalSpace === true}>
               <div className="flex flex-row items-center justify-start gap-4 rounded-md p-1">
                 <Globe className="h-6 w-6" />
                 <div className="flex grow flex-col justify-start gap-2 text-left">
@@ -494,7 +499,7 @@ function VisibilityField({
                 </div>
               </div>
             </SelectItem>
-            {canAddSpace?.private ? (
+            {personalSpace === true || canAddSpace?.private ? (
               <SelectItem
                 value="private"
                 className="hover:bg-base-3 w-full rounded-sm">


### PR DESCRIPTION
## What does this PR do?

Fixes ENG-140
Personal spaces can always be made private regardless of pro plan
Once affected spaces are private again, we don't allow to open them to avoid confusion


## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Read [Contributing Guide](https://github.com/un/inbox/blob/main/CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Tested my code in a local environment
- [ ] Commented on my code in hard-to-understand areas
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the UnInbox Docs if changes were necessary
