### PR TITLE
fix: use constant-time comparison for auth credentials (CWE-208)

### DIFF
--- a/apps/mail-bridge/app.ts
+++ b/apps/mail-bridge/app.ts
@@ -15,7 +15,18 @@ import { opentelemetry } from '@u22n/otel/hono';
 import { trpcMailBridgeRouter } from './trpc';
 import type { Ctx, TRPCContext } from './ctx';
 import { db } from '@u22n/database';
+import { timingSafeEqual, createHash } from 'crypto';
 import { env } from './env';
+
+function safeEqual(a: string, b: string): boolean {
+  try {
+    const hashA = createHash('sha256').update(a).digest();
+    const hashB = createHash('sha256').update(b).digest();
+    return timingSafeEqual(hashA, hashB);
+  } catch {
+    return false;
+  }
+}
 
 const processCleanup: Array<() => Promise<void>> = [];
 
@@ -31,7 +42,7 @@ if (env.MAILBRIDGE_MODE === 'dual' || env.MAILBRIDGE_MODE === 'handler') {
 
   setupTrpcHandler(app, trpcMailBridgeRouter, (_, c) => {
     const authToken = c.req.header('Authorization');
-    const isServiceAuthenticated = authToken === env.MAILBRIDGE_KEY;
+    const isServiceAuthenticated = authToken ? safeEqual(authToken, env.MAILBRIDGE_KEY) : false;
     return {
       auth: isServiceAuthenticated,
       db,

--- a/ee/apps/billing/app.ts
+++ b/ee/apps/billing/app.ts
@@ -15,7 +15,18 @@ import { trpcBillingRouter } from './trpc';
 import { stripeData } from './stripe';
 import { db } from '@u22n/database';
 import { type Ctx } from './ctx';
+import { timingSafeEqual, createHash } from 'crypto';
 import { env } from './env';
+
+function safeEqual(a: string, b: string): boolean {
+  try {
+    const hashA = createHash('sha256').update(a).digest();
+    const hashB = createHash('sha256').update(b).digest();
+    return timingSafeEqual(hashA, hashB);
+  } catch {
+    return false;
+  }
+}
 
 await validateLicense();
 
@@ -28,7 +39,7 @@ setupErrorHandlers(app);
 setupTrpcHandler(app, trpcBillingRouter, (_, c) => {
   const authToken = c.req.header('Authorization');
   return {
-    auth: authToken === env.BILLING_KEY,
+    auth: authToken ? safeEqual(authToken, env.BILLING_KEY) : false,
     stripe: stripeData,
     db
   };


### PR DESCRIPTION
## Summary
Fixes #787 — replaces timing-vulnerable `===` comparison with constant-time `timingSafeEqual` via SHA-256 digest in two service auth checks.

## Changes
- **ee/apps/billing/app.ts**: Replace `authToken === env.BILLING_KEY` with `safeEqual()`
- **apps/mail-bridge/app.ts**: Replace `authToken === env.MAILBRIDGE_KEY` with `safeEqual()`
- Add `safeEqual()` helper using `crypto.createHash` + `crypto.timingSafeEqual`
- No behavioral change for valid authentication flows

## CWE Reference
- **CWE-208**: Observable Timing Discrepancy
- Uses stdlib only (`crypto`) — no new dependencies

---
*Found by [SpiderShield](https://github.com/teehooai/spidershield) security scanner*